### PR TITLE
App crashed while attempting to "auto" add new keys

### DIFF
--- a/src/migrations/2014_04_02_193005_create_translations_table.php
+++ b/src/migrations/2014_04_02_193005_create_translations_table.php
@@ -15,7 +15,7 @@ class CreateTranslationsTable extends Migration {
         Schema::create('ltm_translations', function(Blueprint $table)
         {
             $table->increments('id');
-            $table->integer('status');
+            $table->integer('status')->default(0);
             $table->string('locale');
             $table->string('group');
             $table->string('key');


### PR DESCRIPTION
Without a default value for the status field, the SQL crashes while attempting to "automatically" add new keys using the "Barryvdh\TranslationManager\TranslationServiceProvider"
