### PR TITLE
Replaced static path to lang files with variable one

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -40,7 +40,7 @@ class Manager{
     public function importTranslations($replace = false)
     {
         $counter = 0;
-        foreach($this->files->directories(base_path('resources/lang')) as $langPath){
+        foreach($this->files->directories($this->app->langPath()) as $langPath){
             $locale = basename($langPath);
 
             foreach($this->files->files($langPath) as $file){
@@ -138,7 +138,7 @@ class Manager{
             foreach($tree as $locale => $groups){
                 if(isset($groups[$group])){
                     $translations = $groups[$group];
-                    $path = base_path('resources/lang/'.$locale.'/'.$group.'.php');
+                    $path = $this->app->langPath().'/'.$locale.'/'.$group.'.php';
                     $output = "<?php\n\nreturn ".var_export($translations, true).";\n";
                     $this->files->put($path, $output);
                 }


### PR DESCRIPTION
This is needed when you override the default Illuminate\Foundation\Application. It should be now be compatible with any possible future changes from Taylor as well. 