### PR TITLE
Configurable base and language directory paths.

### DIFF
--- a/config/translation-manager.php
+++ b/config/translation-manager.php
@@ -36,4 +36,18 @@ return array(
 	 */
 	'exclude_groups' => array(),
 
+    /**
+     * Laravel base path (path that should be scanned for translatable strings). Default is this installation itself.
+     *
+     * @type string
+     */
+    // 'base_path' => (__DIR__) . '/../../../some_path',
+
+    /**
+     * Laravel language directory path (path language files will be exported to). Default is this installation itself.
+     *
+     * @type string
+     */
+    // 'lang_path' => (__DIR__) . '/../../../some_path/resources/lang',
+
 );


### PR DESCRIPTION
This update will allow users to specify which Laravel base directory to read translation from, and which directory to write languages files too.

This is incredibly useful if you are working on a complex setup with multiple Laravel instances, one of which have the translations you need read / modify, and another one acting as an administration tool where you actually want to change them from.