### PR TITLE
[FIX] trim value to avoid trailing spaces in the translations 

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -91,7 +91,7 @@ class Controller extends BaseController
                 'group' => $group,
                 'key' => $key,
             ]);
-            $translation->value = (string) $value ?: null;
+            $translation->value = trim((string) $value) ?: null;
             $translation->status = Translation::STATUS_CHANGED;
             $translation->save();
             return array('status' => 'ok');


### PR DESCRIPTION
trailing spaces in translations can't be edited/removed later because they won't show up in the edit box 