### PR TITLE
Added middleware for Laravel 5.2

### DIFF
--- a/config/translation-manager.php
+++ b/config/translation-manager.php
@@ -12,7 +12,10 @@ return array(
     */
     'route' => [
         'prefix' => 'translations',
-        'middleware' => 'auth',
+        'middleware' => [
+	        'web',
+	        'auth',
+		],
     ],
 
 	/**


### PR DESCRIPTION
Since the `web` middleware wasn't speficied, the package couldn't access session variables and wouldn't work.