### PR TITLE
Update regex to match exact methods

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -94,6 +94,7 @@ class Manager{
         $keys = array();
         $functions =  array('trans', 'trans_choice', 'Lang::get', 'Lang::choice', 'Lang::trans', 'Lang::transChoice', '@lang', '@choice');
         $pattern =                              // See http://regexr.com/392hu
+            "[^\w]".                            // Must not have an alphanum or underscore before real method
             "(".implode('|', $functions) .")".  // Must start with one of the functions
             "\(".                               // Match opening parenthese
             "[\'\"]".                           // Match " or '

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -94,7 +94,7 @@ class Manager{
         $keys = array();
         $functions =  array('trans', 'trans_choice', 'Lang::get', 'Lang::choice', 'Lang::trans', 'Lang::transChoice', '@lang', '@choice');
         $pattern =                              // See http://regexr.com/392hu
-            "[^\w]".                            // Must not have an alphanum or underscore before real method
+            "[^\w|>]".                          // Must not have an alphanum or _ or > before real method
             "(".implode('|', $functions) .")".  // Must start with one of the functions
             "\(".                               // Match opening parenthese
             "[\'\"]".                           // Match " or '


### PR DESCRIPTION
Check: https://regex101.com/r/jS5fX0/2

This little tweak will enhance matching exact methods, so for example the following won't get matched:

```
differentMethodtrans('group.key');
Method1trans('lang.file');
some_other_method_trans('lang.file');
$object->trans('lang.line');
```