### PR TITLE
Bugfix: Can't process empty arrays of key in lang file(s)

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -60,6 +60,10 @@ class Manager{
                 $translations = \Lang::getLoader()->load($locale, $group);
                 if ($translations && is_array($translations)) {
                     foreach(array_dot($translations) as $key => $value){
+                        // process only string values
+                        if(is_array($value)){
+                            continue;
+                        }
                         $value = (string) $value;
                         $translation = Translation::firstOrNew(array(
                             'locale' => $locale,


### PR DESCRIPTION
If the value of a key in a language file is an empty array like `"custom" => array()`, then `array_dot` Laravel method doesn't flatten that array and the code `$value = (string) $value;` results in `Array to string conversion` error, so skip processing such keys.