### PR TITLE
Fix Missing argument when delete a key

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -106,7 +106,7 @@ class Controller extends BaseController
         }
     }
 
-    public function postDelete($group, $sub_group = null, $key)
+    public function postDelete($group, $key, $sub_group = null)
     {
         if(!in_array($group, $this->manager->getConfig('exclude_groups')) && $this->manager->getConfig('delete_enabled')) {
             Translation::where('group', $group)->where('key', $key)->delete();


### PR DESCRIPTION
Fix delete key when $sub_group is missing.
![2016-05-12_063840](https://cloud.githubusercontent.com/assets/6972407/15211965/3b2d6378-180c-11e6-9408-d2efdefbfe51.png)
