### PR TITLE
Added compatibility to exportAllTranslations for Postgres

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -159,7 +159,19 @@ class Manager{
 
     public function exportAllTranslations()
     {
-        $groups = Translation::whereNotNull('value')->select(DB::raw('DISTINCT `group`'))->get('group');
+        $select = '';
+
+        switch (DB::getDriverName()) {
+            case 'mysql':
+                $select = 'DISTINCT `group`';
+                break;
+
+            default:
+                $select = 'DISTINCT "group"';
+                break;
+        }
+
+        $groups = Translation::whereNotNull('value')->select(DB::raw($select))->get('group');
 
         foreach($groups as $group){
             $this->exportTranslations($group->group);


### PR DESCRIPTION
MySQL uses ' or " to quote values (i.e. WHERE name = "John"). PostgreSQL uses double quotes to quote system identifiers; field names, table names, etc. (i.e. WHERE "last name" = 'Smith').
