### PR TITLE
Remove route controller - Implicit controller routes have been removed in Laravel 5.3

### DIFF
--- a/src/ManagerServiceProvider.php
+++ b/src/ManagerServiceProvider.php
@@ -85,8 +85,14 @@ class ManagerServiceProvider extends ServiceProvider {
 
         $router->group($config, function($router)
         {
-            $router->get('view/{group}', 'Controller@getView');
-            $router->controller('/', 'Controller');
+            $router->get('view/{group?}', 'Controller@getView');
+            $router->get('/{group?}', 'Controller@getIndex');
+            $router->post('/add', 'Controller@postAdd');
+            $router->post('/edit/{group}', 'Controller@postEdit');
+            $router->post('/delete', 'Controller@postDelete');
+            $router->post('/import', 'Controller@postImport');
+            $router->post('/find', 'Controller@postFind');
+            $router->post('/publish', 'Controller@postPublish');
         });
 	}
 


### PR DESCRIPTION
Hi @barryvdh,
Route controller is removed in Laravel 5.3 and I got error when using this package with Laravel 5.3 so I change your routes.
Please review and merge it.
Thanks!