### PR TITLE
Fix loadLocales for Laravel 5.1

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -59,8 +59,8 @@ class Controller extends BaseController
 
     protected function loadLocales()
     {
-        //Set the default locale as the first one.
-        $locales = Translation::groupBy('locale')->pluck('locale');
+        //Set the default locale as the first one. 
+        $locales = Translation::groupBy('locale')->get()->pluck('locale');
 
         if ($locales instanceof Collection) {
             $locales = $locales->all();


### PR DESCRIPTION
Pluck in 5.2 is like lists in 5.1 for a collection but pluck for an Eloquent Builder return a whatever the column type is. 
https://laravel.com/api/5.1/Illuminate/Database/Eloquent/Builder.html#method_pluck
And it is no good for array_merge. 

Thanks :)