### PR TITLE
Allow default "group" dropdown label to be translated

### DIFF
--- a/resources/views/index.php
+++ b/resources/views/index.php
@@ -122,6 +122,7 @@
         <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
         <div class="form-group">
             <select name="group" id="group" class="form-control group-select">
+                <option value="">Choose a group</option>
                 <?php foreach($groups as $key => $value): ?>
                     <option value="<?= $key ?>"<?= $key == $group ? ' selected':'' ?>><?= $value ?></option>
                 <?php endforeach; ?>

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -28,7 +28,6 @@ class Controller extends BaseController
         if ($groups instanceof Collection) {
             $groups = $groups->all();
         }
-        $groups = [''=>'Choose a group'] + $groups;
         $numChanged = Translation::where('group', $group)->where('status', Translation::STATUS_CHANGED)->count();
 
 


### PR DESCRIPTION
Default label 'Choose a group' should not be hardcoded in `Controller.php`, and should be put in template instead, so it could be translated later by overriding` index.php`. After all, this software is multilingual by definition :) 