### PR TITLE
Using path.lang instead of getLangPath()

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -40,7 +40,7 @@ class Manager{
     public function importTranslations($replace = false)
     {
         $counter = 0;
-        foreach($this->files->directories($this->app->langPath()) as $langPath){
+        foreach($this->files->directories($this->app['path.lang']) as $langPath){
             $locale = basename($langPath);
 
             foreach($this->files->allfiles($langPath) as $file) {
@@ -148,7 +148,7 @@ class Manager{
             foreach($tree as $locale => $groups){
                 if(isset($groups[$group])){
                     $translations = $groups[$group];
-                    $path = $this->app->langPath().'/'.$locale.'/'.$group.'.php';
+                    $path = $this->app['path.lang'].'/'.$locale.'/'.$group.'.php';
                     $output = "<?php\n\nreturn ".var_export($translations, true).";\n";
                     $this->files->put($path, $output);
                 }


### PR DESCRIPTION
Just in case you have a project which overloads the path.lang in the container, I switched $this->app->langPath() for $this->app['path.lang']. 

This way, overloaded or not, the translation manager can work with the proper translation path.

See: https://github.com/laravel/framework/blob/5.3/src/Illuminate/Foundation/Application.php#L280