### PR TITLE
Adds get before pluck in order to get some 5.1 LTS compatibility

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -24,7 +24,7 @@ class Controller extends BaseController
             $groups->whereNotIn('group', $excludedGroups);
         }
 
-        $groups = $groups->pluck('group', 'group');
+        $groups = $groups->get()->pluck('group', 'group');
         if ($groups instanceof Collection) {
             $groups = $groups->all();
         }


### PR DESCRIPTION
Installing in Laravel 5.1 (the LTS version) breaks because of the change in ->pluck() from 5.1 to 5.2 (see issue #146 ) 