### PR TITLE
Fixed Groupping error on PostgreSQL

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -60,7 +60,10 @@ class Controller extends BaseController
     protected function loadLocales()
     {
         //Set the default locale as the first one. 
-        $locales = Translation::groupBy('locale')->get()->pluck('locale');
+        $locales = Translation::groupBy('locale')
+            ->select('locale')
+            ->get()
+            ->pluck('locale');
 
         if ($locales instanceof Collection) {
             $locales = $locales->all();


### PR DESCRIPTION
SQLSTATE[42803]: Grouping error: 7 ERROR: column "ltm_translations.id" must appear in the GROUP BY clause or be used in an aggregate function

![image](https://cloud.githubusercontent.com/assets/688954/21177843/1327d6f2-c1d4-11e6-9bcc-d6cd77a04765.png)
