### PR TITLE
Fixed PotgreSQL, error with grouping

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -24,7 +24,7 @@ class Controller extends BaseController
             $groups->whereNotIn('group', $excludedGroups);
         }
 
-        $groups = $groups->get()->pluck('group', 'group');
+        $groups = $groups->select('group')->get()->pluck('group', 'group');
         if ($groups instanceof Collection) {
             $groups = $groups->all();
         }


### PR DESCRIPTION
Fixed bellow error:

SQLSTATE[42803]: Grouping error: 7 ERROR: column "ltm_translations.id" must appear in the GROUP BY clause or be used in an aggregate function