### PR TITLE
Only select group to avoid SQL error

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -18,7 +18,7 @@ class Controller extends BaseController
     public function getIndex($group = null)
     {
         $locales = $this->loadLocales();
-        $groups = Translation::groupBy('group');
+        $groups = Translation::groupBy('group')->select('group');
         $excludedGroups = $this->manager->getConfig('exclude_groups');
         if($excludedGroups){
             $groups->whereNotIn('group', $excludedGroups);


### PR DESCRIPTION
This change fixes the "SQLSTATE[42000]: Syntax error or access violation: 1055 Expression" error.