### PR TITLE
Add beauty array print option

### DIFF
--- a/config/translation-manager.php
+++ b/config/translation-manager.php
@@ -36,4 +36,13 @@ return array(
 	 */
 	'exclude_groups' => array(),
 
+	/**
+	 * Determine output arrays in lang files, not support php < 5.4
+ 	 * By default, its using array syntax php < 5.4, (standart var_export function)
+	 * If true, set short version of array and 4 space delimeter
+	 *
+	 * @type boolean
+	 *
+	 */
+	'beauty_output' => true
 );

--- a/config/translation-manager.php
+++ b/config/translation-manager.php
@@ -44,5 +44,5 @@ return array(
 	 * @type boolean
 	 *
 	 */
-	'beauty_output' => true
+	'beauty_arrays' => false
 );

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -157,6 +157,24 @@ class Manager{
         }
     }
 
+    private function beautyPrint($langValue, $indent="") {
+        switch (gettype($langValue)) {
+            case 'string':
+                return str_replace("\"","'", '"' . addcslashes($langValue, "\\\"\r\n\t\v\f") . '"');
+            case 'array':
+                $indexed = array_keys($langValue) === range(0, count($langValue) - 1);
+                $r = [];
+                foreach ($langValue as $key => $value) {
+                    $r[] = "$indent    "
+                        . ($indexed ? "" : $this->beautyPrint($key) . " => ")
+                        . $this->beautyPrint($value, "$indent    ");
+                }
+                return "[\n" . implode(",\n", $r) . "\n" . $indent . "]";
+            default:
+                return var_export($langValue, true);
+        }
+    }
+
     public function exportAllTranslations()
     {
         $select = '';

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -149,7 +149,8 @@ class Manager{
                 if(isset($groups[$group])){
                     $translations = $groups[$group];
                     $path = $this->app['path.lang'].'/'.$locale.'/'.$group.'.php';
-                    $output = "<?php\n\nreturn ".var_export($translations, true).";\n";
+                    $output = "<?php\n\nreturn " . ($this->config['beauty_output'] ? $this->beautyPrintArray($translations) : var_export($translations, true)).";\n";
+                
                     $this->files->put($path, $output);
                 }
             }
@@ -157,7 +158,7 @@ class Manager{
         }
     }
 
-    private function beautyPrint($langValue, $indent="") {
+    private function beautyPrintArray($langValue, $indent="") {
         switch (gettype($langValue)) {
             case 'string':
                 return str_replace("\"","'", '"' . addcslashes($langValue, "\\\"\r\n\t\v\f") . '"');
@@ -166,8 +167,8 @@ class Manager{
                 $r = [];
                 foreach ($langValue as $key => $value) {
                     $r[] = "$indent    "
-                        . ($indexed ? "" : $this->beautyPrint($key) . " => ")
-                        . $this->beautyPrint($value, "$indent    ");
+                        . ($indexed ? "" : $this->beautyPrintArray($key) . " => ")
+                        . $this->beautyPrintArray($value, "$indent    ");
                 }
                 return "[\n" . implode(",\n", $r) . "\n" . $indent . "]";
             default:

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -149,7 +149,7 @@ class Manager{
                 if(isset($groups[$group])){
                     $translations = $groups[$group];
                     $path = $this->app['path.lang'].'/'.$locale.'/'.$group.'.php';
-                    $output = "<?php\n\nreturn " . ($this->config['beauty_output'] ? $this->beautyPrintArray($translations) : var_export($translations, true)).";\n";
+                    $output = "<?php\n\nreturn " . ($this->config['beauty_arrays'] ? $this->beautyPrintArray($translations) : var_export($translations, true)).";\n";
                 
                     $this->files->put($path, $output);
                 }


### PR DESCRIPTION
It often required that code fits psr, but direct writing from output of function var_export break it. Also, for compatibly with php < 5.4, there possible add option for this case?

From

return array (
  'test' => 'Test',
  'test1' => 'Test',
  'test2' =>
  array (
    'test' =>
    array (
      'test' =>
      array (
        'test' =>
        array (
          'test' => 'Test',
        ),
      ),
    ),
  ),
);

To

return [
    'test' => 'Test',
    'test1' => 'Test',
    'test2' => [
        'test' => [
            'test' => [
                'test' => [
                    'test' => 'Test'
                ]
            ]
        ]
    ]
];