### PR TITLE
Add export 'sort_keys' config option

### DIFF
--- a/config/translation-manager.php
+++ b/config/translation-manager.php
@@ -36,4 +36,9 @@ return array(
 	 */
 	'exclude_groups' => array(),
 
+	/**
+	 * Export translations with keys output alphabetically.
+	 */
+	'sort_keys ' => false,
+
 );

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -143,7 +143,7 @@ class Manager{
             if($group == '*')
                 return $this->exportAllTranslations();
 
-            $tree = $this->makeTree(Translation::where('group', $group)->whereNotNull('value')->get());
+            $tree = $this->makeTree(Translation::ofTranslatedGroup($group)->get());
 
             foreach($tree as $locale => $groups){
                 if(isset($groups[$group])){
@@ -153,25 +153,13 @@ class Manager{
                     $this->files->put($path, $output);
                 }
             }
-            Translation::where('group', $group)->whereNotNull('value')->update(array('status' => Translation::STATUS_SAVED));
+            Translation::ofTranslatedGroup($group)->update(array('status' => Translation::STATUS_SAVED));
         }
     }
 
     public function exportAllTranslations()
     {
-        $select = '';
-
-        switch (DB::getDriverName()) {
-            case 'mysql':
-                $select = 'DISTINCT `group`';
-                break;
-
-            default:
-                $select = 'DISTINCT "group"';
-                break;
-        }
-
-        $groups = Translation::whereNotNull('value')->select(DB::raw($select))->get('group');
+        $groups = Translation::whereNotNull('value')->selectDistinctGroup()->get('group');
 
         foreach($groups as $group){
             $this->exportTranslations($group->group);

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -143,7 +143,7 @@ class Manager{
             if($group == '*')
                 return $this->exportAllTranslations();
 
-            $tree = $this->makeTree(Translation::ofTranslatedGroup($group)->get());
+            $tree = $this->makeTree(Translation::ofTranslatedGroup($group)->orderByGroupKeys($this->config['sort_keys'])->get());
 
             foreach($tree as $locale => $groups){
                 if(isset($groups[$group])){

--- a/src/Models/Translation.php
+++ b/src/Models/Translation.php
@@ -22,4 +22,25 @@ class Translation extends Model{
     protected $table = 'ltm_translations';
     protected $guarded = array('id', 'created_at', 'updated_at');
 
+    public function scopeOfTranslatedGroup($query, $group)
+    {
+        return $query->where('group', $group)->whereNotNull('value');
+    }
+
+    public function scopeSelectDistinctGroup($query)
+    {
+        $select = '';
+
+        switch (DB::getDriverName()){
+            case 'mysql':
+                $select = 'DISTINCT `group`';
+                break;
+            default:
+                $select = 'DISTINCT "group"';
+                break;
+        }
+
+        return $query->select(DB::raw($select));
+    }
+
 }

--- a/src/Models/Translation.php
+++ b/src/Models/Translation.php
@@ -27,6 +27,14 @@ class Translation extends Model{
         return $query->where('group', $group)->whereNotNull('value');
     }
 
+    public function scopeOrderByGroupKeys($query, $ordered) {
+        if ($ordered) {
+            $query->orderBy('group')->orderBy('key');
+        }
+
+        return $query;
+    }
+
     public function scopeSelectDistinctGroup($query)
     {
         $select = '';


### PR DESCRIPTION
Sorry for this long-winded description, but I want to clearly communicate my reason to allow sorting of the output array files.

## Use Case

Working with translations with a continuous deployment schedule, I found this package has a developer experience gap that makes source code version control difficult. For example:

* Initially developers only add English translation keys in subdirectory `resources/lang/en/*`
* A third-party translator is given a URL to this package's UI in a dev or UAT environment to translate new locale keys recently introduced to the app.
* Stakeholders review those translations before they're merged to the master branch and deployed to production.
* This package export ability is used to create the new translation files in a separate branch and a new pull request.
* In the week-long gap for this process, other parts of the app are being developed with even _more_  translation keys introduced (or existing one's updated!) to the locale subdirectory.

This package outputs the `resources/lang/*` array files in an arbitrary order. Generally each line is output ascending according to `ltm_translations` database table's generated auto-increment keys (MySQL) or sequence (Postgresql.)

The problem is when it comes time to merge with the master branch. Without a consistent ordering for these keys, it's easy to lose keys recently introduced. It's also almost impossible to find if there are actual conflicts in keys that already existed.

By keeping keys sorted alphabetically, this becomes an easy process and one less headache for developers and pull request reviewers.

## Implementation

* I made this configuration value `false` by default so existing users won't be affected and it's purely an opt-in setting.
* I refactored some of the `Manager` query building into `Translation` model scopes to keep the service class small and also to remove the repeating `where('group', $group)->whereNotNull('value')`.
* I wasn't quite sure what conventions to stick with as it looks like a couple contributors' styles have leaked into the package. Have you thought about adding a `.php_cs` configuration to this project? I saw laravel-ide-helper has a .styleci.yml to enforce PSR-2 so maybe it would be good to do the same for this package too?

Otherwise, keep up the good work with open source. I also regularly use laravel-debugbar and laravel-ide-helper which I'm quite happy with.