### PR TITLE
Added a slash as separator to iterate with subdirectories when use find command.

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -104,7 +104,7 @@ class Manager{
             "[\'\"]".                           // Match " or '
             "(".                                // Start a new group to match:
                 "[a-zA-Z0-9_-]+".               // Must start with group
-                "([.][^\1)]+)+".                // Be followed by one or more items/keys
+                "([.|\/][^\1)]+)+".             // Be followed by one or more items/keys
             ")".                                // Close group
             "[\'\"]".                           // Closing quote
             "[\),]";                            // Close parentheses or new parameter


### PR DESCRIPTION
This PR is ralated in the issue #185 
eg. trans('subdirectory/language.line', 1);