### PR TITLE
Add support for vue file import

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -111,7 +111,7 @@ class Manager{
 
         // Find all PHP + Twig files in the app folder, except for storage
         $finder = new Finder();
-        $finder->in($path)->exclude('storage')->name('*.php')->name('*.twig')->files();
+        $finder->in($path)->exclude('storage')->name('*.php')->name('*.twig')->name('*.vue')->files();
 
         /** @var \Symfony\Component\Finder\SplFileInfo $file */
         foreach ($finder as $file) {


### PR DESCRIPTION
Hi,

You can use the same syntax in javascript as in the blade and twig templates, so a I think a lot of people want to use this package to edit the translations in vue components. With this patch the trans keys will be imported from vue files.

Laracast reference:
https://laracasts.com/discuss/channels/vue/use-trans-in-vuejs