### PR TITLE
Fixed $key argument not being passed to the postDelete method

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -102,7 +102,7 @@ class Controller extends BaseController
         }
     }
 
-    public function postDelete($group = null)
+    public function postDelete($group = null, $key)
     {
         if(!in_array($group, $this->manager->getConfig('exclude_groups')) && $this->manager->getConfig('delete_enabled')) {
             Translation::where('group', $group)->where('key', $key)->delete();


### PR DESCRIPTION
Fixed $key argument not being passed to the postDelete method, therefore running into a 500 Internal Server Error.

The change was made in the Controller.php