### PR TITLE
Renaming the fire() functions to handle()

### DIFF
--- a/src/Console/CleanCommand.php
+++ b/src/Console/CleanCommand.php
@@ -1,10 +1,12 @@
-<?php namespace Barryvdh\TranslationManager\Console;
+<?php
+
+namespace Barryvdh\TranslationManager\Console;
 
 use Barryvdh\TranslationManager\Manager;
 use Illuminate\Console\Command;
 
-class CleanCommand extends Command {
-
+class CleanCommand extends Command
+{
     /**
      * The console command name.
      *
@@ -19,7 +21,7 @@ class CleanCommand extends Command {
      */
     protected $description = 'Clean empty translations';
 
-    /** @var \Barryvdh\TranslationManager\Manager  */
+    /** @var \Barryvdh\TranslationManager\Manager */
     protected $manager;
 
     public function __construct(Manager $manager)
@@ -30,13 +32,10 @@ class CleanCommand extends Command {
 
     /**
      * Execute the console command.
-     *
-     * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->manager->cleanTranslations();
-        $this->info("Done cleaning translations");
+        $this->info('Done cleaning translations');
     }
-
 }

--- a/src/Console/ExportCommand.php
+++ b/src/Console/ExportCommand.php
@@ -1,12 +1,14 @@
-<?php namespace Barryvdh\TranslationManager\Console;
+<?php
+
+namespace Barryvdh\TranslationManager\Console;
 
 use Barryvdh\TranslationManager\Manager;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
-class ExportCommand extends Command {
-
+class ExportCommand extends Command
+{
     /**
      * The console command name.
      *
@@ -21,7 +23,7 @@ class ExportCommand extends Command {
      */
     protected $description = 'Export translations to PHP files';
 
-    /** @var \Barryvdh\TranslationManager\Manager  */
+    /** @var \Barryvdh\TranslationManager\Manager */
     protected $manager;
 
     public function __construct(Manager $manager)
@@ -32,30 +34,30 @@ class ExportCommand extends Command {
 
     /**
      * Execute the console command.
-     *
-     * @return void
      */
-    public function fire()
+    public function handle()
     {
         $group = $this->argument('group');
         $json = $this->option('json');
 
         if (is_null($group) && !$json) {
-            $this->warn("You must either specify a group argument or export as --json");
+            $this->warn('You must either specify a group argument or export as --json');
+
             return;
         }
 
         if (!is_null($group) && $json) {
-            $this->warn("You cannot use both group argument and --json option at the same time");
+            $this->warn('You cannot use both group argument and --json option at the same time');
+
             return;
         }
 
         $this->manager->exportTranslations($group, $json);
 
         if (!is_null($group)) {
-            $this->info("Done writing language files for " . (($group == '*') ? 'ALL groups' : $group . " group") );
-        } else if ($json) {
-            $this->info("Done writing JSON language files for translation strings");
+            $this->info('Done writing language files for '.(($group == '*') ? 'ALL groups' : $group.' group'));
+        } elseif ($json) {
+            $this->info('Done writing JSON language files for translation strings');
         }
     }
 
@@ -66,9 +68,9 @@ class ExportCommand extends Command {
      */
     protected function getArguments()
     {
-        return array(
-            array('group', InputArgument::OPTIONAL, 'The group to export (`*` for all).'),
-        );
+        return [
+            ['group', InputArgument::OPTIONAL, 'The group to export (`*` for all).'],
+        ];
     }
 
     /**
@@ -78,10 +80,8 @@ class ExportCommand extends Command {
      */
     protected function getOptions()
     {
-        return array(
-            array('json', "J", InputOption::VALUE_NONE, 'Export anonymous strings to JSON'),
-        );
+        return [
+            ['json', 'J', InputOption::VALUE_NONE, 'Export anonymous strings to JSON'],
+        ];
     }
-
-
 }

--- a/src/Console/FindCommand.php
+++ b/src/Console/FindCommand.php
@@ -1,10 +1,12 @@
-<?php namespace Barryvdh\TranslationManager\Console;
+<?php
+
+namespace Barryvdh\TranslationManager\Console;
 
 use Barryvdh\TranslationManager\Manager;
 use Illuminate\Console\Command;
 
-class FindCommand extends Command {
-
+class FindCommand extends Command
+{
     /**
      * The console command name.
      *
@@ -19,7 +21,7 @@ class FindCommand extends Command {
      */
     protected $description = 'Find translations in php/twig files';
 
-    /** @var  \Barryvdh\TranslationManager\Manager  */
+    /** @var \Barryvdh\TranslationManager\Manager */
     protected $manager;
 
     public function __construct(Manager $manager)
@@ -28,18 +30,12 @@ class FindCommand extends Command {
         parent::__construct();
     }
 
-
     /**
      * Execute the console command.
-     *
-     * @return void
      */
-    public function fire()
+    public function handle()
     {
         $counter = $this->manager->findTranslations(null);
-        $this->info('Done importing, processed '.$counter. ' items!');
-
+        $this->info('Done importing, processed '.$counter.' items!');
     }
-
-
 }

--- a/src/Console/ImportCommand.php
+++ b/src/Console/ImportCommand.php
@@ -1,11 +1,13 @@
-<?php namespace Barryvdh\TranslationManager\Console;
+<?php
+
+namespace Barryvdh\TranslationManager\Console;
 
 use Barryvdh\TranslationManager\Manager;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;
 
-class ImportCommand extends Command {
-
+class ImportCommand extends Command
+{
     /**
      * The console command name.
      *
@@ -20,7 +22,7 @@ class ImportCommand extends Command {
      */
     protected $description = 'Import translations from the PHP sources';
 
-    /** @var  \Barryvdh\TranslationManager\Manager  */
+    /** @var \Barryvdh\TranslationManager\Manager */
     protected $manager;
 
     public function __construct(Manager $manager)
@@ -29,18 +31,14 @@ class ImportCommand extends Command {
         parent::__construct();
     }
 
-
     /**
      * Execute the console command.
-     *
-     * @return void
      */
-    public function fire()
+    public function handle()
     {
         $replace = $this->option('replace');
         $counter = $this->manager->importTranslations($replace);
-        $this->info('Done importing, processed '.$counter. ' items!');
-
+        $this->info('Done importing, processed '.$counter.' items!');
     }
 
     /**
@@ -50,10 +48,8 @@ class ImportCommand extends Command {
      */
     protected function getOptions()
     {
-        return array(
-            array('replace', "R", InputOption::VALUE_NONE, 'Replace existing keys'),
-        );
+        return [
+            ['replace', 'R', InputOption::VALUE_NONE, 'Replace existing keys'],
+        ];
     }
-
-
 }

--- a/src/Console/ResetCommand.php
+++ b/src/Console/ResetCommand.php
@@ -1,10 +1,12 @@
-<?php namespace Barryvdh\TranslationManager\Console;
+<?php
+
+namespace Barryvdh\TranslationManager\Console;
 
 use Illuminate\Console\Command;
 use Barryvdh\TranslationManager\Manager;
 
-class ResetCommand extends Command {
-
+class ResetCommand extends Command
+{
     /**
      * The console command name.
      *
@@ -19,7 +21,7 @@ class ResetCommand extends Command {
      */
     protected $description = 'Delete all translations from the database';
 
-    /** @var \Barryvdh\TranslationManager\Manager  */
+    /** @var \Barryvdh\TranslationManager\Manager */
     protected $manager;
 
     public function __construct(Manager $manager)
@@ -30,14 +32,10 @@ class ResetCommand extends Command {
 
     /**
      * Execute the console command.
-     *
-     * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->manager->truncateTranslations();
-        $this->info("All translations are deleted");
+        $this->info('All translations are deleted');
     }
-
-
 }


### PR DESCRIPTION
Laravel 5.5 seems to expect the console commands to have a handle function instead of a fire function.