### PR TITLE
Enable json on publish button

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -127,7 +127,13 @@ class Controller extends BaseController
 
     public function postPublish($group = null)
     {
-        $this->manager->exportTranslations($group);
+         $json = false;
+
+        if($group === '_json'){
+            $json = true;
+        }
+
+        $this->manager->exportTranslations($group, $json);
 
         return ['status' => 'ok'];
     }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -187,7 +187,7 @@ class Manager{
 
     public function exportTranslations($group = null, $json = false)
     {
-        if (!is_null($group)) {
+        if (!is_null($group) && !$json) {
             if (!in_array($group, $this->config['exclude_groups'])) {
                 if ($group == '*')
                     return $this->exportAllTranslations();
@@ -198,7 +198,7 @@ class Manager{
                     if (isset($groups[$group])) {
                         $translations = $groups[$group];
                         $path = $this->app['path.lang'] . '/' . $locale . '/' . $group . '.php';
-                        $output = "<?php\n\nreturn " . var_export($translations, true) . ";\n";
+                        $output = "<?php\n\nreturn " . var_export($translations, true) . ";".\PHP_EOL;
                         $this->files->put($path, $output);
                     }
                 }
@@ -213,7 +213,7 @@ class Manager{
                 if(isset($groups[self::JSON_GROUP])){
                     $translations = $groups[self::JSON_GROUP];
                     $path = $this->app['path.lang'].'/'.$locale.'.json';
-                    $output = json_encode($translations, true);
+                    $output = json_encode($translations, \JSON_PRETTY_PRINT);
                     $this->files->put($path, $output);
                 }
             }


### PR DESCRIPTION
Currently the publish button can't save to {locale}.json.

It will always try to save to {locale}/_json.php.

This PR fixes that, and allows you to save the _json to the correct {locale}.json, which is the exact same as running `php artisan translations:export --json`