### PR TITLE
Fixes windows group path when importing translations

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -52,6 +52,7 @@ class Manager{
                     continue;
                 }
                 $subLangPath = str_replace($langPath . DIRECTORY_SEPARATOR, "", $info['dirname']);
+                $subLangPath = str_replace(DIRECTORY_SEPARATOR, "/", $subLangPath);
                 if ($subLangPath != $langPath) {
                     $group = $subLangPath . "/" . $group;
                 }


### PR DESCRIPTION
Because Windows uses `\` and Unix uses `/` the result was when having path like this:
`C:\...\resources\lang\en\dir\sub\dir\file.php` would be parsed to this group:

`dir\sub\dir/file.php` But that is wrong and resulted in empty values for files in subdirectories.

This PR should fix this.