### PR TITLE
Update Manager.php will create not existing locale directory

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -198,7 +198,12 @@ class Manager{
                 foreach ($tree as $locale => $groups) {
                     if (isset($groups[$group])) {
                         $translations = $groups[$group];
-                        $path = $this->app['path.lang'] . '/' . $locale . '/' . $group . '.php';
+                        $path = $this->app['path.lang'] . '/' . $locale;
+                        if(!is_dir($path)){
+                            mkdir($path, 0777, true);
+                        }
+                        $path = $path . '/' . $group . '.php';
+                        
                         $output = "<?php\n\nreturn " . var_export($translations, true) . ";".\PHP_EOL;
                         $this->files->put($path, $output);
                     }


### PR DESCRIPTION
if don't have language directory. it will create language directory.
i want remove this error on publish and export.
file_put_contents(path/lang/ {locale} / {group} .php): failed to open stream: No such file or directory