### PR TITLE
Fix Manager class preventing Artisan tests when this package is installed

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -1,9 +1,9 @@
 <?php namespace Barryvdh\TranslationManager;
 
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Events\Dispatcher;
 use Barryvdh\TranslationManager\Models\Translation;
-use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\DB;
 use Symfony\Component\Finder\Finder;
 
@@ -11,11 +11,11 @@ class Manager{
 
     const JSON_GROUP = '_json';
 
-    /** @var \Illuminate\Foundation\Application  */
+    /** @var \Illuminate\Contracts\Foundation\Application  */
     protected $app;
     /** @var \Illuminate\Filesystem\Filesystem  */
     protected $files;
-    /** @var \Illuminate\Events\Dispatcher  */
+    /** @var \Illuminate\Contracts\Events\Dispatcher  */
     protected $events;
 
     protected $config;


### PR DESCRIPTION
This fixes https://github.com/barryvdh/laravel-translation-manager/issues/239 for any `TestCase` calls to `$this->artisan()` when this package is installed.

This is the error I was seeing from `$this->withoutEvents()` being called in a test before `$this->artisan()`:

> TypeError: Argument 3 passed to Barryvdh\TranslationManager\Manager::__construct()
must be an instance of Illuminate\Events\Dispatcher, instance of
Mockery_0_Illuminate_Contracts_Events_Dispatcher given

By typehinting the Manager class constructor with concrete implementations, this package will affect Artisan tests in applications with Laravel 5.5 auto-discovery enabled.

e.g., `Event::fake()` or `$this->withoutEvents()` calls during Artisan integration tests will cause service provider singleton registrations for this package's commands to fail since the object passed in isn't a concrete `Illuminate\Events\Dispatcher`.

Instead use inversion of control to dependency inject by resolving Laravel contracts.