### PR TITLE
Added orderBy clause to alphabetically order top level groups dropdown

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -24,7 +24,7 @@ class Controller extends BaseController
             $groups->whereNotIn('group', $excludedGroups);
         }
 
-        $groups = $groups->select('group')->get()->pluck('group', 'group');
+        $groups = $groups->select('group')->orderBy('group')->get()->pluck('group', 'group');
         if ($groups instanceof Collection) {
             $groups = $groups->all();
         }
@@ -148,7 +148,7 @@ class Controller extends BaseController
         else
         {
             return redirect()->back();
-        }       
+        }
     }
 
     public function postAddLocale(Request $request)


### PR DESCRIPTION
Just a small change to order the top level groups dropdown alphabetically as it can get unwieldy if there are a lot.