### PR TITLE
Provide possibility to exclude subfolder e.g. vendor

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -133,6 +133,10 @@ class Controller extends BaseController
             $json = true;
         }
 
+        if($group == null){
+            return ['status' => 'Not ok'];
+        }
+
         $this->manager->exportTranslations($group, $json);
 
         return ['status' => 'ok'];

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -54,12 +54,19 @@ class Manager{
 
         foreach ($this->files->directories($this->app['path.lang']) as $langPath) {
             $locale = basename($langPath);
+
+            if(in_array($locale, $this->config['exclude_langs'])) {
+                continue;
+            }
+
             foreach ($this->files->allfiles($langPath) as $file) {
                 $info = pathinfo($file);
                 $group = $info['filename'];
+                
                 if (in_array($group, $this->config['exclude_groups'])) {
                     continue;
                 }
+
                 $subLangPath = str_replace($langPath . DIRECTORY_SEPARATOR, "", $info['dirname']);
                 $subLangPath = str_replace(DIRECTORY_SEPARATOR, "/", $subLangPath);
                 $langPath = str_replace(DIRECTORY_SEPARATOR, "/", $langPath);

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -5,6 +5,7 @@ use Illuminate\Events\Dispatcher;
 use Barryvdh\TranslationManager\Models\Translation;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Symfony\Component\Finder\Finder;
 
 class Manager{
@@ -40,11 +41,15 @@ class Manager{
     public function missingKey($namespace, $group, $key)
     {
         if(!in_array($group, $this->config['exclude_groups'])) {
-            Translation::firstOrCreate(array(
+            $translation = Translation::firstOrCreate(array(
                 'locale' => $this->app['config']['app.locale'],
                 'group' => $group,
                 'key' => $key,
             ));
+            if($translation->wasRecentlyCreated){
+                $message = "Missing translation located. Locale: ". $this->app['config']['app.locale'] ." Group: ". $group ." Key: ". $key;
+                Log::warning($message);
+            }
         }
     }
 

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -62,11 +62,11 @@ class Manager{
             foreach ($this->files->allfiles($langPath) as $file) {
                 $info = pathinfo($file);
                 $group = $info['filename'];
-                
+
                 if (in_array($group, $this->config['exclude_groups'])) {
                     continue;
                 }
-
+                
                 $subLangPath = str_replace($langPath . DIRECTORY_SEPARATOR, "", $info['dirname']);
                 $subLangPath = str_replace(DIRECTORY_SEPARATOR, "/", $subLangPath);
                 $langPath = str_replace(DIRECTORY_SEPARATOR, "/", $langPath);

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -51,54 +51,45 @@ class Manager{
     public function importTranslations($replace = false)
     {
         $counter = 0;
-
-        foreach ($this->files->directories($this->app['path.lang']) as $langPath) {
+        foreach($this->files->directories($this->app['path.lang']) as $langPath) {
             $locale = basename($langPath);
-
-            if(in_array($locale, $this->config['exclude_langs'])) {
+            if(in_array($locale, $this->config['exclude_langs']))
                 continue;
-            }
-
-            foreach ($this->files->allfiles($langPath) as $file) {
+            foreach($this->files->allfiles($langPath) as $file) {
                 $info = pathinfo($file);
                 $group = $info['filename'];
-
-                if (in_array($group, $this->config['exclude_groups'])) {
+                if(in_array($group, $this->config['exclude_groups']))
                     continue;
-                }
-                
                 $subLangPath = str_replace($langPath . DIRECTORY_SEPARATOR, "", $info['dirname']);
-                $subLangPath = str_replace(DIRECTORY_SEPARATOR, "/", $subLangPath);
-                $langPath = str_replace(DIRECTORY_SEPARATOR, "/", $langPath);
-
                 if ($subLangPath != $langPath) {
                     $group = $subLangPath . "/" . $group;
                 }
+                $group = str_replace('\\', '/', $group);
                 $translations = \Lang::getLoader()->load($locale, $group);
-                if ($translations && is_array($translations)) {
-                    foreach (array_dot($translations) as $key => $value) {
-                        $importedTranslation = $this->importTranslation($key, $value, $locale, $group, $replace);
-                        $counter += $importedTranslation ? 1 : 0;
-                    }
+                if (!$translations || !is_array($translations))
+                    continue;
+                foreach(array_dot($translations) as $key => $value) {
+                    if(is_array($value)) // process only string values
+                        continue;
+
+                    $value = (string) $value;
+                    $translation = Translation::firstOrNew([
+                        'locale' => $locale,
+                        'group' => $group,
+                        'key' => $key,
+                    ]);
+                    // Check if the database is different then the files
+                    $newStatus = $translation->value === $value || !$translation->value ? Translation::STATUS_SAVED : Translation::STATUS_CHANGED;
+                    if($newStatus !== (int) $translation->status)
+                        $translation->status = $newStatus;
+                    // Only replace when empty, or explicitly told so
+                    if($replace || !$translation->value)
+                        $translation->value = $value;
+                    $translation->save();
+                    $counter++;
                 }
             }
         }
-
-        foreach ($this->files->files($this->app['path.lang']) as $jsonTranslationFile) {
-            if (strpos($jsonTranslationFile, '.json') === false) {
-                continue;
-            }
-            $locale = basename($jsonTranslationFile, '.json');
-            $group = self::JSON_GROUP;
-            $translations = \Lang::getLoader()->load($locale, '*', '*'); // Retrieves JSON entries of the given locale only
-            if ($translations && is_array($translations)) {
-                foreach ($translations as $key => $value) {
-                    $importedTranslation = $this->importTranslation($key, $value, $locale, $group, $replace);
-                    $counter += $importedTranslation ? 1 : 0;
-                }
-            }
-        }
-
         return $counter;
     }
 


### PR DESCRIPTION
Hi guys,

I have made the experience that the vendor folder within langs can break the whole process to translate custom text. The vendor folder leads to a own language "vendor" and the other languages like en, de etc are not listed anymore. With that we can exclude the vendor folder optional.

In long time perspective I recommend to rethink the importTranslations function to make it more flexible.