### PR TITLE
Subfolders when exporting group

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -209,13 +209,11 @@ class Manager{
                 foreach ($tree as $locale => $groups) {
                     if (isset($groups[$group])) {
                         $translations = $groups[$group];
-                        $path = $this->app['path.lang'] . '/' . $locale;
 
-                        if(!is_dir($path)){
-                            mkdir($path, 0777, true);
-                        }
+                        $path = $this->app['path.lang'] . DIRECTORY_SEPARATOR . $locale;
+                        $locale_path = $locale . DIRECTORY_SEPARATOR . $group;
 
-                        $subfolders = explode(DIRECTORY_SEPARATOR, $group);
+                        $subfolders = explode(DIRECTORY_SEPARATOR, $locale_path);
                         unset($subfolders[count($subfolders)-1]);
 
                         $subfolder_level = '';
@@ -227,7 +225,7 @@ class Manager{
                             }
                         }
 
-                        $path = $path . '/' . $group . '.php';
+                        $path = $path . DIRECTORY_SEPARATOR . $group . '.php';
 
                         $output = "<?php\n\nreturn " . var_export($translations, true) . ";".\PHP_EOL;
                         $this->files->put($path, $output);

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -209,8 +209,8 @@ class Manager{
                 foreach ($tree as $locale => $groups) {
                     if (isset($groups[$group])) {
                         $translations = $groups[$group];
-                        $path = $this->app['path.lang'] . DIRECTORY_SEPARATOR . $locale;
-                        
+                        $path = $this->app['path.lang'];
+
                         $locale_path = $locale . DIRECTORY_SEPARATOR . $group;
                         $subfolders = explode(DIRECTORY_SEPARATOR, $locale_path);
                         array_pop($subfolders);
@@ -219,12 +219,13 @@ class Manager{
                         foreach($subfolders as $subfolder){
                             $subfolder_level = $subfolder_level . $subfolder . DIRECTORY_SEPARATOR;
 
-                            if(!is_dir($path . DIRECTORY_SEPARATOR . $subfolder_level)){
-                                mkdir($path . DIRECTORY_SEPARATOR . $subfolder_level, 0777, true);
+                            $temp_path = rtrim($path . DIRECTORY_SEPARATOR . $subfolder_level, DIRECTORY_SEPARATOR);
+                            if(!is_dir($temp_path)){
+                                mkdir($temp_path, 0777, true);
                             }
                         }
 
-                        $path = $path . DIRECTORY_SEPARATOR . $group . '.php';
+                        $path = $path . DIRECTORY_SEPARATOR . $locale . DIRECTORY_SEPARATOR . $group . '.php';
 
                         $output = "<?php\n\nreturn " . var_export($translations, true) . ";".\PHP_EOL;
                         $this->files->put($path, $output);

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -210,11 +210,25 @@ class Manager{
                     if (isset($groups[$group])) {
                         $translations = $groups[$group];
                         $path = $this->app['path.lang'] . '/' . $locale;
+
                         if(!is_dir($path)){
                             mkdir($path, 0777, true);
                         }
+
+                        $subfolders = explode(DIRECTORY_SEPARATOR, $group);
+                        unset($subfolders[count($subfolders)-1]);
+
+                        $subfolder_level = '';
+                        foreach($subfolders as $subfolder){
+                            $subfolder_level = $subfolder_level . $subfolder . DIRECTORY_SEPARATOR;
+
+                            if(!is_dir($path . DIRECTORY_SEPARATOR . $subfolder_level)){
+                                mkdir($path . DIRECTORY_SEPARATOR . $subfolder_level, 0777, true);
+                            }
+                        }
+
                         $path = $path . '/' . $group . '.php';
-                        
+
                         $output = "<?php\n\nreturn " . var_export($translations, true) . ";".\PHP_EOL;
                         $this->files->put($path, $output);
                     }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -209,12 +209,11 @@ class Manager{
                 foreach ($tree as $locale => $groups) {
                     if (isset($groups[$group])) {
                         $translations = $groups[$group];
-
                         $path = $this->app['path.lang'] . DIRECTORY_SEPARATOR . $locale;
+                        
                         $locale_path = $locale . DIRECTORY_SEPARATOR . $group;
-
                         $subfolders = explode(DIRECTORY_SEPARATOR, $locale_path);
-                        unset($subfolders[count($subfolders)-1]);
+                        array_pop($subfolders);
 
                         $subfolder_level = '';
                         foreach($subfolders as $subfolder){


### PR DESCRIPTION
A fix for creating subfolders before you create the actual group file, it would yield a `"failed to open stream: No such file or directory"` exception without this fix.

An example is running the following export command:
`php artisan translation:export "master/other/companies"`

it would try to `file_put_contents` the entire path plus the `companies.php` file, but file_put_contents does not create subfolders on it's own. With this fix it will create the subfolders if they don't exist and then create the file like it's supposed to instead of throwing an exception.

Behaviour before this pull request is basically to just create the locale folder, but assume nobody ever uses subfolders and then throw an exception when they do.