### PR TITLE
Fix export '_json' group, when call export all groups console command

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -244,7 +244,7 @@ class Manager{
         $groups = Translation::whereNotNull('value')->selectDistinctGroup()->get('group');
 
         foreach($groups as $group){
-            if ($group == self::JSON_GROUP) {
+            if ($group->group == self::JSON_GROUP) {
                 $this->exportTranslations(null, true);
             } else {
                 $this->exportTranslations($group->group);


### PR DESCRIPTION
you can see this problem when you call the "php artisan translations:export '*'" console command to export all groups.

the condition to check if the group is '_json' group is wrong, you check the $group Variable instead of $group->group 

the code then handle the '_json' group as a normal group and create a '_json.php' file in the lang folder , as example 'lang/en/_json.php'  instead of 'lang/en.json'

I hoppe that you accept this pull request ASAP.

Best Reagrd's