### PR TITLE
Show raw HTML

### DIFF
--- a/resources/views/index.php
+++ b/resources/views/index.php
@@ -196,15 +196,15 @@
             <tbody>
 
             <?php foreach ($translations as $key => $translation): ?>
-                <tr id="<?php echo $key ?>">
-                    <td><?php echo $key ?></td>
+                <tr id="<?php echo htmlentities($key, ENT_QUOTES, 'UTF-8', false) ?>">
+                    <td><?php echo htmlentities($key, ENT_QUOTES, 'UTF-8', false) ?></td>
                     <?php foreach ($locales as $locale): ?>
                         <?php $t = isset($translation[$locale]) ? $translation[$locale] : null ?>
 
                         <td>
                             <a href="#edit"
                                class="editable status-<?php echo $t ? $t->status : 0 ?> locale-<?php echo $locale ?>"
-                               data-locale="<?php echo $locale ?>" data-name="<?php echo $locale . "|" . $key ?>"
+                               data-locale="<?php echo $locale ?>" data-name="<?php echo $locale . "|" . htmlentities($key, ENT_QUOTES, 'UTF-8', false) ?>"
                                id="username" data-type="textarea" data-pk="<?php echo $t ? $t->id : 0 ?>"
                                data-url="<?php echo $editUrl ?>"
                                data-title="Enter translation"><?php echo $t ? htmlentities($t->value, ENT_QUOTES, 'UTF-8', false) : '' ?></a>
@@ -214,7 +214,7 @@
                         <td>
                             <a href="<?php echo action('\Barryvdh\TranslationManager\Controller@postDelete', [$group, $key]) ?>"
                                class="delete-key"
-                               data-confirm="Are you sure you want to delete the translations for '<?php echo $key ?>?"><span
+                               data-confirm="Are you sure you want to delete the translations for '<?php echo htmlentities($key, ENT_QUOTES, 'UTF-8', false) ?>?"><span
                                         class="glyphicon glyphicon-trash"></span></a>
                         </td>
                     <?php endif; ?>


### PR DESCRIPTION
Don't render HTML when printing it to the screen, but show the RAW representation only.