### PR TITLE
Change from string to text-column

### DIFF
--- a/database/migrations/2014_04_02_193005_create_translations_table.php
+++ b/database/migrations/2014_04_02_193005_create_translations_table.php
@@ -18,7 +18,7 @@ class CreateTranslationsTable extends Migration {
             $table->integer('status')->default(0);
             $table->string('locale');
             $table->string('group');
-            $table->string('key');
+            $table->text('key');
             $table->text('value')->nullable();
             $table->timestamps();
         });


### PR DESCRIPTION
Allow key-column to store more than 255 characters (for example, when translating large strings via `{{ __('very long string') }}`.