### PR TITLE
Add remote sync and translation api endpoint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
     "require": {
         "php": ">=5.4.0",
         "symfony/finder": "~2.3|~3.0",
-        "stichoza/google-translate-php": "~3.2"
         "illuminate/support": "5.0.x|5.1.x|5.2.x|5.3.x|5.4.x|5.5.x",
         "illuminate/translation": "5.0.x|5.1.x|5.2.x|5.3.x|5.4.x|5.5.x",
+        "stichoza/google-translate-php": "~3.2",
         "symfony/finder": "~2.3|~3.0"
     },
     "autoload": {

--- a/config/translation-manager.php
+++ b/config/translation-manager.php
@@ -1,19 +1,42 @@
 <?php
 
-return array(
+return [
 
-    /*
-    |--------------------------------------------------------------------------
-    | Routes group config
-    |--------------------------------------------------------------------------
-    |
-    | The default group settings for the elFinder routes.
-    |
+    /**
+    * Routes group config
+    *
+    * The default group settings for the elFinder routes.
     */
     'route' => [
         'prefix' => 'translations',
         'middleware' => 'auth',
     ],
+    
+    /**
+     * Enable API endpoints
+     *
+     * If you want to use this package in an API, you can expose the translations with this flag.
+     * See php artisan route:list or ManagerServiceProvider.php for available routes.
+     */
+    'api_endpoints_enabled' => env('TRANSLATION_API_ENDPOINTS', false),
+
+    /**
+     * Api route settings
+     *
+     * You can set route group configuration here.
+     * If a parameter is not provided the default translation group setting will be used.
+     *
+     */
+    'api_route' => [
+        'prefix' => 'locale',
+        'middleware' => '',
+    ],
+
+    /**
+     * Set if the API endpoints should use the database content, instead of the default translation files
+     * Warning: Setting this to true will allow the query of unpublished translations.
+     */
+    'api_use_database' => env('TRANSLATION_API_USE_DB', false),
 
 	/**
 	 * Enable deletion of translations
@@ -39,6 +62,5 @@ return array(
 	/**
 	 * Export translations with keys output alphabetically.
 	 */
-	'sort_keys ' => false,
-
-);
+	'sort_keys' => false,
+];

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ This way, translations can be saved in git history and no overhead is introduced
 
 Require this package in your composer.json and run composer update (or run `composer require barryvdh/laravel-translation-manager` directly):
 
-    "barryvdh/laravel-translation-manager": "0.2.x"
+    "barryvdh/laravel-translation-manager": "0.2.x@dev"
 
 After updating composer, add the ServiceProvider to the providers array in config/app.php
 

--- a/resources/views/index.php
+++ b/resources/views/index.php
@@ -289,12 +289,13 @@
                 return node.innerText == props[3];
             }
             $("#auto-translate").click(function(){
-                var $btn = $(this),
-                    $empties = $(".editable.status-0:hasText('Empty')").not(".locale-en"),
-                    done = 0;
-                if($empties.length) {
-                    $btn.button('loading');
-                    $empties.each(function(){
+                var btn = $(this);
+                var empties = $("a.editable.editable-empty:hasText('Empty')").not(".locale-en");
+                var done = 0;
+                console.log(empties);
+                if(empties.length) {
+                    btn.button('loading');
+                    empties.each(function(){
                         var $this = $(this),
                             nameNow = $this.data("name"),
                             nameEn = nameNow.replace(/.+?\|/, "en|"),
@@ -310,8 +311,8 @@
                             $this.editable('option', {value: data.value});
                             $this.removeClass('status-0').addClass('status-1 text-danger');
                             done++;
-                            if(done == $empties.length) {
-                                $btn.button('reset');
+                            if(done == empties.length) {
+                                btn.button('reset');
                             }
                         });
                     });

--- a/resources/views/index.php
+++ b/resources/views/index.php
@@ -22,7 +22,6 @@
 
             $.ajaxSetup({
                 beforeSend: function(xhr, settings) {
-                    console.log('beforesend');
                     settings.data += "&_token=<?php echo csrf_token() ?>";
                 }
             });

--- a/resources/views/index.php
+++ b/resources/views/index.php
@@ -163,7 +163,7 @@
                 <?php endforeach; ?>
                 <?php if($deleteEnabled): ?>
                     <td>
-                        <a href="<?= action('\Barryvdh\TranslationManager\Controller@postDelete', [$group, $key]) ?>" class="delete-key" data-confirm="Are you sure you want to delete the translations for '<?= $key ?>?"><span class="glyphicon glyphicon-trash"></span></a>
+                        <a href="<?= action('\Barryvdh\TranslationManager\Controller@postDelete', [urlencode($group), urlencode($key)]) ?>" class="delete-key" data-confirm="Are you sure you want to delete the translations for '<?= $key ?>?"><span class="glyphicon glyphicon-trash"></span></a>
                     </td>
                 <?php endif; ?>
             </tr>

--- a/resources/views/index.php
+++ b/resources/views/index.php
@@ -271,7 +271,7 @@
                         </form>
                     </div>
                     <div class="col-sm-1">
-                        <a target="_blank" class="btn btn-link" href="<?php echo action('\Barryvdh\TranslationManager\Controller@downloadLangFiles') ?>">Download translations</a>
+                        <a target="_blank" class="btn btn-link" href="<?php echo action('\Barryvdh\TranslationManager\Controller@downloadLangFiles') ?>">Download published translations</a>
                     </div>
                 </div>
             </div>

--- a/resources/views/index.php
+++ b/resources/views/index.php
@@ -270,7 +270,19 @@
 
     <?php endif; ?>
 
-    <button type="button" id="auto-translate" class="btn btn-primary" data-loading-text="Translating...">Auto Translate</button>
+    <div class="form-group">
+        <div class="row" style="margin-left: inherit">
+            <label>Auto translate</label>
+        </div>
+        <div class="row" style="margin-left: inherit">
+            Translate this group with Google Translate. The english translation must be available.
+        </div>
+        <div class="row" style="margin-left: inherit; padding-top: 5px">
+            <button type="button" id="auto-translate" class="btn btn-primary" data-loading-text="Translating...">Auto Translate</button>
+            <small><a target="_blank" href="https://github.com/Stichoza/google-translate-php#disclaimer">Do not overuse this function!</a></small>
+        </div>
+    </div>
+
     <script>
         jQuery(document).ready(function($){
             $.expr[':']['hasText'] = function(node, index, props){

--- a/resources/views/index.php
+++ b/resources/views/index.php
@@ -262,12 +262,20 @@
         </fieldset>
         <fieldset>
             <legend>Export all translations</legend>
-            <form class="form-inline form-publish-all" method="POST" action="<?php echo action('\Barryvdh\TranslationManager\Controller@postPublish', '*') ?>" data-remote="true" role="form" data-confirm="Are you sure you want to publish all translations group? This will overwrite existing language files.">
-                <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
-                <button type="submit" class="btn btn-primary" data-disable-with="Publishing.." >Publish all</button>
-            </form>
+            <div class="form-group">
+                <div class="row">
+                    <div class="col-sm-1">
+                        <form class="form-inline form-publish-all" method="POST" action="<?php echo action('\Barryvdh\TranslationManager\Controller@postPublish', '*') ?>" data-remote="true" role="form" data-confirm="Are you sure you want to publish all translations group? This will overwrite existing language files.">
+                            <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
+                            <button type="submit" class="btn btn-primary" data-disable-with="Publishing.." >Publish all</button>
+                        </form>
+                    </div>
+                    <div class="col-sm-1">
+                        <a target="_blank" class="btn btn-link" href="<?php echo action('\Barryvdh\TranslationManager\Controller@downloadLangFiles') ?>">Download translations</a>
+                    </div>
+                </div>
+            </div>
         </fieldset>
-
     <?php endif; ?>
 
     <div class="form-group">

--- a/resources/views/index.php
+++ b/resources/views/index.php
@@ -292,7 +292,6 @@
                 var btn = $(this);
                 var empties = $("a.editable.editable-empty:hasText('Empty')").not(".locale-en");
                 var done = 0;
-                console.log(empties);
                 if(empties.length) {
                     btn.button('loading');
                     empties.each(function(){

--- a/resources/views/index.php
+++ b/resources/views/index.php
@@ -23,7 +23,7 @@
             $.ajaxSetup({
                 beforeSend: function(xhr, settings) {
                     console.log('beforesend');
-                    settings.data += "&_token=<?= csrf_token() ?>";
+                    settings.data += "&_token=<?php echo csrf_token() ?>";
                 }
             });
 
@@ -43,9 +43,9 @@
             $('.group-select').on('change', function(){
                 var group = $(this).val();
                 if (group) {
-                    window.location.href = '<?= action('\Barryvdh\TranslationManager\Controller@getView') ?>/'+$(this).val();
+                    window.location.href = '<?php echo action('\Barryvdh\TranslationManager\Controller@getView') ?>/'+$(this).val();
                 } else {
-                    window.location.href = '<?= action('\Barryvdh\TranslationManager\Controller@getIndex') ?>';
+                    window.location.href = '<?php echo action('\Barryvdh\TranslationManager\Controller@getIndex') ?>';
                 }
             });
 
@@ -62,24 +62,44 @@
             $('.form-import').on('ajax:success', function (e, data) {
                 $('div.success-import strong.counter').text(data.counter);
                 $('div.success-import').slideDown();
+                window.location.reload();
             });
 
             $('.form-find').on('ajax:success', function (e, data) {
                 $('div.success-find strong.counter').text(data.counter);
                 $('div.success-find').slideDown();
+                window.location.reload();
             });
 
             $('.form-publish').on('ajax:success', function (e, data) {
                 $('div.success-publish').slideDown();
             });
 
+            $('.form-publish-all').on('ajax:success', function (e, data) {
+                $('div.success-publish-all').slideDown();
+            });
+
         })
     </script>
 </head>
 <body>
-<div style="width: 80%; margin: auto;">
-    <h1>Translation Manager</h1>
-    <p>Warning, translations are not visible until they are exported back to the app/lang file, using 'php artisan translation:export' command or publish button.</p>
+<header class="navbar navbar-static-top navbar-inverse" id="top" role="banner">
+    <div class="container-fluid">
+        <div class="navbar-header">
+            <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+            <a href="<?php echo action('\Barryvdh\TranslationManager\Controller@getIndex') ?>" class="navbar-brand">
+                Translation Manager
+            </a>
+        </div>
+    </div>
+</header>
+<div class="container-fluid">
+    <p>Warning, translations are not visible until they are exported back to the app/lang file, using <code>php artisan translation:export</code> command or publish button.</p>
     <div class="alert alert-success success-import" style="display:none;">
         <p>Done importing, processed <strong class="counter">N</strong> items! Reload this page to refresh the groups!</p>
     </div>
@@ -87,7 +107,10 @@
         <p>Done searching for translations, found <strong class="counter">N</strong> items!</p>
     </div>
     <div class="alert alert-success success-publish" style="display:none;">
-        <p>Done publishing the translations for group '<?= $group ?>'!</p>
+        <p>Done publishing the translations for group '<?php echo $group ?>'!</p>
+    </div>
+    <div class="alert alert-success success-publish-all" style="display:none;">
+        <p>Done publishing the translations for all group!</p>
     </div>
     <?php if(Session::has('successPublish')) : ?>
         <div class="alert alert-info">
@@ -96,83 +119,155 @@
     <?php endif; ?>
     <p>
         <?php if(!isset($group)) : ?>
-        <form class="form-inline form-import" method="POST" action="<?= action('\Barryvdh\TranslationManager\Controller@postImport') ?>" data-remote="true" role="form">
+        <form class="form-import" method="POST" action="<?php echo action('\Barryvdh\TranslationManager\Controller@postImport') ?>" data-remote="true" role="form">
             <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
-            <select name="replace" class="form-control">
-                <option value="0">Append new translations</option>
-                <option value="1">Replace existing translations</option>
-            </select>
-            <button type="submit" class="btn btn-success"  data-disable-with="Loading..">Import groups</button>
+            <div class="form-group">
+                <div class="row">
+                    <div class="col-sm-3">
+                        <select name="replace" class="form-control">
+                            <option value="0">Append new translations</option>
+                            <option value="1">Replace existing translations</option>
+                        </select>
+                    </div>
+                    <div class="col-sm-2">
+                    <button type="submit" class="btn btn-success btn-block"  data-disable-with="Loading..">Import groups</button>
+                    </div>
+                </div>
+            </div>
         </form>
-        <form class="form-inline form-find" method="POST" action="<?= action('\Barryvdh\TranslationManager\Controller@postFind') ?>" data-remote="true" role="form" data-confirm="Are you sure you want to scan you app folder? All found translation keys will be added to the database.">
-            <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
-            <p></p>
-            <button type="submit" class="btn btn-info" data-disable-with="Searching.." >Find translations in files</button>
+        <form class="form-find" method="POST" action="<?php echo action('\Barryvdh\TranslationManager\Controller@postFind') ?>" data-remote="true" role="form" data-confirm="Are you sure you want to scan you app folder? All found translation keys will be added to the database.">
+            <div class="form-group">
+                <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
+                <button type="submit" class="btn btn-info" data-disable-with="Searching.." >Find translations in files</button>
+            </div>
         </form>
         <?php endif; ?>
         <?php if(isset($group)) : ?>
-            <form class="form-inline form-publish" method="POST" action="<?= action('\Barryvdh\TranslationManager\Controller@postPublish', $group) ?>" data-remote="true" role="form" data-confirm="Are you sure you want to publish the translations group '<?= $group ?>? This will overwrite existing language files.">
+            <form class="form-inline form-publish" method="POST" action="<?php echo action('\Barryvdh\TranslationManager\Controller@postPublish', $group) ?>" data-remote="true" role="form" data-confirm="Are you sure you want to publish the translations group '<?php echo $group ?>? This will overwrite existing language files.">
                 <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
                 <button type="submit" class="btn btn-info" data-disable-with="Publishing.." >Publish translations</button>
                 <a href="<?= action('\Barryvdh\TranslationManager\Controller@getIndex') ?>" class="btn btn-default">Back</a>
             </form>
         <?php endif; ?>
     </p>
-    <form role="form">
+    <form role="form" method="POST" action="<?php echo action('\Barryvdh\TranslationManager\Controller@postAddGroup') ?>">
         <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
         <div class="form-group">
+            <p>Choose a group to display the group translations. If no groups are visisble, make sure you have run the migrations and imported the translations.</p>
             <select name="group" id="group" class="form-control group-select">
                 <?php foreach($groups as $key => $value): ?>
-                    <option value="<?= $key ?>"<?= $key == $group ? ' selected':'' ?>><?= $value ?></option>
+                    <option value="<?php echo $key ?>"<?php echo $key == $group ? ' selected':'' ?>><?php echo $value ?></option>
                 <?php endforeach; ?>
             </select>
         </div>
+        <div class="form-group">
+            <label>Enter a new group name and start edit translations in that group</label>
+            <input type="text" class="form-control" name="new-group" />
+        </div>
+        <div class="form-group">
+            <input type="submit" class="btn btn-default" name="add-group" value="Add and edit keys" />
+        </div>
     </form>
     <?php if($group): ?>
-        <form action="<?= action('\Barryvdh\TranslationManager\Controller@postAdd', array($group)) ?>" method="POST"  role="form">
+        <form action="<?php echo action('\Barryvdh\TranslationManager\Controller@postAdd', array($group)) ?>" method="POST"  role="form">
             <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
-            <textarea class="form-control" rows="3" name="keys" placeholder="Add 1 key per line, without the group prefix"></textarea>
-            <p></p>
-            <input type="submit" value="Add keys" class="btn btn-primary">
+            <div class="form-group">
+                <label>Add new keys to this group</label>
+                <textarea class="form-control" rows="3" name="keys" placeholder="Add 1 key per line, without the group prefix"></textarea>
+            </div>
+            <div class="form-group">
+                <input type="submit" value="Add keys" class="btn btn-primary">
+            </div>
         </form>
         <hr>
     <h4>Total: <?= $numTranslations ?>, changed: <?= $numChanged ?></h4>
-    <table class="table">
-        <thead>
-        <tr>
-            <th width="15%">Key</th>
-            <?php foreach($locales as $locale): ?>
-                <th><?= $locale ?></th>
-            <?php endforeach; ?>
-            <?php if($deleteEnabled): ?>
-                <th>&nbsp;</th>
-            <?php endif; ?>
-        </tr>
-        </thead>
-        <tbody>
-
-        <?php foreach($translations as $key => $translation): ?>
-            <tr id="<?= $key ?>">
-                <td><?= $key ?></td>
-                <?php foreach($locales as $locale): ?>
-                    <?php $t = isset($translation[$locale]) ? $translation[$locale] : null?>
-
-                    <td>
-                        <a href="#edit" class="editable status-<?= $t ? $t->status : 0 ?> locale-<?= $locale ?>" data-locale="<?= $locale ?>" data-name="<?= $locale . "|" . $key ?>" id="username" data-type="textarea" data-pk="<?= $t ? $t->id : 0 ?>" data-url="<?= $editUrl ?>" data-title="Enter translation"><?= $t ? htmlentities($t->value, ENT_QUOTES, 'UTF-8', false) : '' ?></a>
-                    </td>
+        <table class="table">
+            <thead>
+            <tr>
+                <th width="15%">Key</th>
+                <?php foreach ($locales as $locale): ?>
+                    <th><?= $locale ?></th>
                 <?php endforeach; ?>
-                <?php if($deleteEnabled): ?>
-                    <td>
-                        <a href="<?= action('\Barryvdh\TranslationManager\Controller@postDelete', [urlencode($group), urlencode($key)]) ?>" class="delete-key" data-confirm="Are you sure you want to delete the translations for '<?= $key ?>?"><span class="glyphicon glyphicon-trash"></span></a>
-                    </td>
+                <?php if ($deleteEnabled): ?>
+                    <th>&nbsp;</th>
                 <?php endif; ?>
             </tr>
-        <?php endforeach; ?>
+            </thead>
+            <tbody>
 
-        </tbody>
-    </table>
+            <?php foreach ($translations as $key => $translation): ?>
+                <tr id="<?php echo $key ?>">
+                    <td><?php echo $key ?></td>
+                    <?php foreach ($locales as $locale): ?>
+                        <?php $t = isset($translation[$locale]) ? $translation[$locale] : null ?>
+
+                        <td>
+                            <a href="#edit"
+                               class="editable status-<?php echo $t ? $t->status : 0 ?> locale-<?php echo $locale ?>"
+                               data-locale="<?php echo $locale ?>" data-name="<?php echo $locale . "|" . $key ?>"
+                               id="username" data-type="textarea" data-pk="<?php echo $t ? $t->id : 0 ?>"
+                               data-url="<?php echo $editUrl ?>"
+                               data-title="Enter translation"><?php echo $t ? htmlentities($t->value, ENT_QUOTES, 'UTF-8', false) : '' ?></a>
+                        </td>
+                    <?php endforeach; ?>
+                    <?php if ($deleteEnabled): ?>
+                        <td>
+                            <a href="<?php echo action('\Barryvdh\TranslationManager\Controller@postDelete', [$group, $key]) ?>"
+                               class="delete-key"
+                               data-confirm="Are you sure you want to delete the translations for '<?php echo $key ?>?"><span
+                                        class="glyphicon glyphicon-trash"></span></a>
+                        </td>
+                    <?php endif; ?>
+                </tr>
+            <?php endforeach; ?>
+            </tbody>
+        </table>
     <?php else: ?>
-        <p>Choose a group to display the group translations. If no groups are visible, make sure you have run the migrations and imported the translations.</p>
+        <fieldset>
+            <legend>Supported locales</legend>
+            <p>
+                Current supported locales:
+            </p>
+            <form  class="form-remove-locale" method="POST" role="form" action="<?php echo action('\Barryvdh\TranslationManager\Controller@postRemoveLocale') ?>" data-confirm="Are you sure to remove this locale and all of data?">
+                <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
+                <ul class="list-locales">
+                <?php foreach($locales as $locale): ?>
+                    <li>
+                        <div class="form-group">
+                            <button type="submit" name="remove-locale[<?php echo $locale ?>]" class="btn btn-danger btn-xs" data-disable-with="...">
+                                &times;
+                            </button>
+                            <?php echo $locale ?>
+                            
+                        </div>
+                    </li>
+                <?php endforeach; ?>
+                </ul>
+            </form>
+            <form class="form-add-locale" method="POST" role="form" action="<?php echo action('\Barryvdh\TranslationManager\Controller@postAddLocale') ?>">
+                <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
+                <div class="form-group">
+                    <p>
+                        Enter new locale key:
+                    </p>
+                    <div class="row">
+                        <div class="col-sm-3">
+                            <input type="text" name="new-locale" class="form-control" />
+                        </div>
+                        <div class="col-sm-2">
+                            <button type="submit" class="btn btn-default btn-block"  data-disable-with="Adding..">Add new locale</button>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </fieldset>
+        <fieldset>
+            <legend>Export all translations</legend>
+            <form class="form-inline form-publish-all" method="POST" action="<?php echo action('\Barryvdh\TranslationManager\Controller@postPublish', '*') ?>" data-remote="true" role="form" data-confirm="Are you sure you want to publish all translations group? This will overwrite existing language files.">
+                <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
+                <button type="submit" class="btn btn-primary" data-disable-with="Publishing.." >Publish all</button>
+            </form>
+        </fieldset>
 
     <?php endif; ?>
 </div>

--- a/src/Console/SyncCommand.php
+++ b/src/Console/SyncCommand.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Barryvdh\TranslationManager\Console;
+
+use Illuminate\Console\Command;
+use Barryvdh\TranslationManager\Manager;
+use Symfony\Component\Console\Input\InputOption;
+
+class SyncCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'translations:sync';
+
+    protected $signature = 'translations:sync '
+        . '{--locales= : Locales to sync. Default: all locales, Example: en,hu}'
+        . '{--url= : Source url with the api route config prefix} '
+        . '{--simulate : Do not save the result, only display it} '
+        . '{--export : Export all translation groups to php files before exit}'
+    ;
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Synchronize translations from a source';
+
+    /** @var \Barryvdh\TranslationManager\Manager */
+    protected $manager;
+
+    public function __construct(Manager $manager)
+    {
+        $this->manager = $manager;
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        if(!$this->option('url')) {
+            $this->error('No url given!');
+            return 1;
+        }
+
+        $this->info('Getting remote locales at: ' . $this->option('url') . '/locales');
+        $remoteLocales = $this->manager->getLocalesFromUrl($this->option('url'));
+        $this->info('Found remote locales: ' . implode(', ', $remoteLocales));
+
+        $localLocales = $this->manager->getLocales();
+        $localesToSync = explode(',', $this->option('locales'));
+
+        if(is_null($localesToSync) || count($localesToSync) == 0 || array_first($localesToSync) == '') {
+            $this->info('No locales to sync provided. Selecting all...');
+            $localesToSync = $localLocales;
+        }
+
+        $this->info('Selected locales: ' . implode(', ', $localesToSync));
+
+        $localesToSync = array_intersect($localesToSync, $remoteLocales);
+
+        $this->info('Found local locales: ' . implode(', ', $localLocales));
+        $this->info('Locales to sync: ' . implode(', ', $localesToSync));
+
+        foreach ($localesToSync as $locale) {
+            $this->info('');
+            $this->info('Syncing locale: ' . $locale);
+
+            $localTranslation = $this->manager->getTranslationsFromDatabase($locale);
+            $remoteTranslation = $this->manager->getTranslationsFromUrl($this->option('url'), $locale);
+
+            $table = [];
+            $translationsToSave = [];
+
+            $keys = array_intersect(array_keys($localTranslation), array_keys($remoteTranslation));
+            foreach ($keys as $key) {
+                $localValue = null;
+                if(array_key_exists($key, $localTranslation)) {
+                    $localValue = $localTranslation[$key];
+                }
+
+                $remoteValue = null;
+                if(array_key_exists($key, $remoteTranslation)) {
+                    $remoteValue = $remoteTranslation[$key];
+                }
+
+                if($remoteValue != $localValue) {
+                    $translationsToSave[$key] = $remoteValue;
+                    $table[$key] = [$key, str_limit($localValue, 75), str_limit($remoteValue, 75)];
+                }
+            }
+
+            $this->info('Changed translations: ' . count($table));
+            if(count($table) > 0) {
+                $this->table(['Key', 'Local database translation', 'Remote translation'], $table);
+            }
+
+            if(!$this->option('simulate')) {
+                $this->info('Saving...');
+                $this->info('Saved: ' . $this->manager->saveTranslations($locale, $translationsToSave));
+            }
+        }
+
+        $this->info('');
+        $this->info('Sync finished!');
+        $this->info('');
+
+        if(!$this->option('simulate') && $this->option('export')) {
+            $this->info('Exporting...');
+            $this->call('translations:export', [
+                'group' => '*',
+            ]);
+        }
+    }
+}

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -87,9 +87,9 @@ class Controller extends BaseController
     public function postEdit($group = null)
     {
         if(!in_array($group, $this->manager->getConfig('exclude_groups'))) {
-            $name = $request->get('name');
-            $value = $request->get('value');
-            $translate = $request->get('translate');
+            $name = request()->get('name');
+            $value = request()->get('value');
+            $translate = request()->get('translate');
 
             list($locale, $key) = explode('|', $name, 2);
             $translation = Translation::firstOrNew([

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -195,4 +195,22 @@ class Controller extends BaseController
     {
         return response()->download($this->manager->zipLangFiles(),'lang.zip')->deleteFileAfterSend(true);
     }
+
+    public function getLocales()
+    {
+        return response()->json($this->manager->getLocales());
+    }
+
+    public function getLocaleTranslations($locale)
+    {
+        if(!in_array($locale, $this->manager->getLocales())) {
+            return response()->json(['error' => 'Locale not found'])->setStatusCode(404);
+        }
+
+        if($this->manager->getConfig('api_use_database', false)) {
+            return response()->json($this->manager->getTranslationsFromDatabase($locale));
+        }
+
+        return response()->json($this->manager->getTranslationsFromFiles($locale));
+    }
 }

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -98,9 +98,22 @@ class Controller extends BaseController
                 'key' => $key,
             ]);
 
-            if($translate == 'auto') {
-                $tr = new TranslateClient('en', $locale);
-                $value = $tr->translate($value);
+            if($translate === 'auto') {
+                // https://github.com/fzaninotto/Faker#fakerprovideruseragent
+                $userAgents = [
+                    'Mozilla/5.0 (Windows CE) AppleWebKit/5350 (KHTML, like Gecko) Chrome/13.0.888.0 Safari/5350',
+                    'Mozilla/5.0 (Macintosh; PPC Mac OS X 10_6_5) AppleWebKit/5312 (KHTML, like Gecko) Chrome/14.0.894.0 Safari/5312',
+                    'Mozilla/5.0 (X11; Linuxi686; rv:7.0) Gecko/20101231 Firefox/3.6',
+                    'Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10_7_1 rv:3.0; en-US) AppleWebKit/534.11.3 (KHTML, like Gecko) Version/4.0 Safari/534.11.3',
+                    'Opera/8.25 (Windows NT 5.1; en-US) Presto/2.9.188 Version/10.00',
+                    'Mozilla/5.0 (compatible; MSIE 7.0; Windows 98; Win 9x 4.90; Trident/3.0)',
+                ];
+                $translateClient = new TranslateClient('en', $locale, [
+                    'headers' => [
+                        'User-Agent' => $userAgents[array_rand($userAgents)]
+                    ]
+                ]);
+                $value = $translateClient->translate($value);
                 $value = preg_replace('#\[__(.+?)__\]#i', ':$1', $value);
             }
             $translation->value = (string) $value ?: null;

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -17,7 +17,7 @@ class Controller extends BaseController
 
     public function getIndex($group = null)
     {
-        $locales = $this->loadLocales();
+        $locales = $this->manager->getLocales();
         $groups = Translation::groupBy('group');
         $excludedGroups = $this->manager->getConfig('exclude_groups');
         if($excludedGroups){
@@ -136,5 +136,37 @@ class Controller extends BaseController
         $this->manager->exportTranslations($group, $json);
 
         return ['status' => 'ok'];
+    }
+
+    public function postAddGroup(Request $request)
+    {
+        $group = str_replace(".", '', $request->input('new-group'));
+        if ($group)
+        {
+            return redirect()->action('\Barryvdh\TranslationManager\Controller@getView',$group);
+        }
+        else
+        {
+            return redirect()->back();
+        }       
+    }
+
+    public function postAddLocale(Request $request)
+    {
+        $locales = $this->manager->getLocales();
+        $newLocale = str_replace([], '-', trim($request->input('new-locale')));
+        if (!$newLocale || in_array($newLocale, $locales)) {
+            return redirect()->back();
+        }
+        $this->manager->addLocale($newLocale);
+        return redirect()->back();
+    }
+
+    public function postRemoveLocale(Request $request)
+    {
+        foreach ($request->input('remove-locale', []) as $locale => $val) {
+            $this->manager->removeLocale($locale);
+        }
+        return redirect()->back();
     }
 }

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -190,4 +190,9 @@ class Controller extends BaseController
         }
         return redirect()->back();
     }
+
+    public function downloadLangFiles()
+    {
+        return response()->download($this->manager->zipLangFiles(),'lang.zip')->deleteFileAfterSend(true);
+    }
 }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -141,7 +141,7 @@ class Manager{
 
         // Find all PHP + Twig files in the app folder, except for storage
         $finder = new Finder();
-        $finder->in($path)->exclude('storage')->name('*.php')->name('*.twig')->files();
+        $finder->in($path)->exclude('storage')->name('*.php')->name('*.twig')->name('*.vue')->files();
 
         /** @var \Symfony\Component\Finder\SplFileInfo $file */
         foreach ($finder as $file) {

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -315,6 +315,15 @@ class Manager{
         }
         return $array;
     }
+    
+    public function jsonSet(&$array, $key, $value)
+    {
+        if (is_null($key)) {
+            return $array = $value;
+        }
+        $array[$key] = $value;
+        return $array;
+    }
 
     public function getConfig($key = null)
     {

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -20,12 +20,21 @@ class Manager{
 
     protected $config;
 
+    protected $locales;
+
+    protected $ignoreLocales;
+
+    protected $ignoreFilePath;
+
     public function __construct(Application $app, Filesystem $files, Dispatcher $events)
     {
         $this->app = $app;
         $this->files = $files;
         $this->events = $events;
         $this->config = $app['config']['translation-manager'];
+        $this->ignoreFilePath = storage_path('.ignore_locales');
+        $this->locales = [];
+        $this->ignoreLocales = $this->getIgnoredLocales();
     }
 
     public function missingKey($namespace, $group, $key)
@@ -53,6 +62,8 @@ class Manager{
                 }
                 $subLangPath = str_replace($langPath . DIRECTORY_SEPARATOR, "", $info['dirname']);
                 $subLangPath = str_replace(DIRECTORY_SEPARATOR, "/", $subLangPath);
+                $langPath = str_replace(DIRECTORY_SEPARATOR, "/", $langPath);
+
                 if ($subLangPath != $langPath) {
                     $group = $subLangPath . "/" . $group;
                 }
@@ -251,6 +262,47 @@ class Manager{
         Translation::truncate();
     }
 
+    public function getLocales()
+    {
+        if (empty($this->locales)) {
+            $locales = array_merge([config('app.locale')], Translation::groupBy('locale')->pluck('locale')->toArray());
+            foreach ($this->files->directories($this->app->langPath()) as $localeDir) {
+                $locales[] = $this->files->name($localeDir);
+            }
+            $this->locales = array_unique($locales);
+            sort($this->locales);
+        }
+
+        return array_diff($this->locales, $this->ignoreLocales);
+    }
+
+    public function addLocale($locale) 
+    {
+        $localeDir = $this->app->langPath() . '/' . $locale;
+
+        $this->ignoreLocales = array_diff($this->ignoreLocales, [$locale]);
+        $this->saveIgnoredLocales();
+        $this->ignoreLocales = $this->getIgnoredLocales();
+
+        if (!$this->files->exists($localeDir) || !$this->files->isDirectory($localeDir)) {
+            return $this->files->makeDirectory($localeDir);
+        }
+
+        return true;
+    }
+
+    public function removeLocale($locale)
+    {
+        if (!$locale) {
+            return false;
+        }
+        $this->ignoreLocales = array_merge($this->ignoreLocales, [$locale]);
+        $this->saveIgnoredLocales();
+        $this->ignoreLocales = $this->getIgnoredLocales();
+
+        Translation::where('locale', $locale)->delete();
+    }
+
     protected function makeTree($translations, $json = false)
     {
         $array = array();
@@ -274,15 +326,19 @@ class Manager{
         }
     }
 
-    public function jsonSet(&$array, $key, $value)
+    protected function getIgnoredLocales()
     {
-        if (is_null($key)) {
-            return $array = $value;
+        if (!$this->files->exists($this->ignoreFilePath))
+        {
+            return [];
         }
+        $result = json_decode($this->files->get($this->ignoreFilePath));
+        return ($result && is_array($result)) ? $result : [];
+    }
 
-        $array[$key] = $value;
-
-        return $array;
+    protected function saveIgnoredLocales()
+    {
+        return $this->files->put($this->ignoreFilePath, json_encode($this->ignoreLocales));
     }
 
 }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -6,6 +6,7 @@ use Barryvdh\TranslationManager\Models\Translation;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\DB;
 use Symfony\Component\Finder\Finder;
+use ZipArchive;
 
 class Manager{
 
@@ -350,4 +351,28 @@ class Manager{
         return $this->files->put($this->ignoreFilePath, json_encode($this->ignoreLocales));
     }
 
+    public function zipLangFiles()
+    {
+        $zip = new ZipArchive();
+        $filePath = public_path('lang.zip');
+
+        if (!$zip->open($filePath, ZipArchive::CREATE) === TRUE) {
+            die("Cannot write to directory");
+        }
+
+        $folderName = 'lang';
+        $zip->addEmptyDir($folderName);
+
+        foreach ($this->files->directories($this->app['path.lang']) as $langPath) {
+            foreach ($this->files->allfiles($langPath) as $file) {
+                $zip->addFile($file->getRealPath(), $folderName . '/' . basename($langPath) . '/' . $file->getFilename());
+            }
+        }
+
+        if(!$zip->close()){
+            die("Cannot close file");
+        }
+
+        return $filePath;
+    }
 }

--- a/src/ManagerServiceProvider.php
+++ b/src/ManagerServiceProvider.php
@@ -78,6 +78,7 @@ class ManagerServiceProvider extends ServiceProvider {
 
         $router->group($config, function($router)
         {
+            $router->get('/locales/download', 'Controller@downloadLangFiles');
             $router->get('view/{groupKey?}', 'Controller@getView')->where('groupKey', '.*');
             $router->get('/{groupKey?}', 'Controller@getIndex')->where('groupKey', '.*');
             $router->post('/add/{groupKey}', 'Controller@postAdd')->where('groupKey', '.*');

--- a/src/ManagerServiceProvider.php
+++ b/src/ManagerServiceProvider.php
@@ -82,9 +82,12 @@ class ManagerServiceProvider extends ServiceProvider {
             $router->get('/{groupKey?}', 'Controller@getIndex')->where('groupKey', '.*');
             $router->post('/add/{groupKey}', 'Controller@postAdd')->where('groupKey', '.*');
             $router->post('/edit/{groupKey}', 'Controller@postEdit')->where('groupKey', '.*');
+            $router->post('/groups/add', 'Controller@postAddGroup');
             $router->post('/delete/{groupKey}/{translationKey}', 'Controller@postDelete')->where('groupKey', '.*');
             $router->post('/import', 'Controller@postImport');
             $router->post('/find', 'Controller@postFind');
+            $router->post('/locales/add', 'Controller@postAddLocale');
+            $router->post('/locales/remove', 'Controller@postRemoveLocale');
             $router->post('/publish/{groupKey}', 'Controller@postPublish')->where('groupKey', '.*');
         });
 	}

--- a/src/ManagerServiceProvider.php
+++ b/src/ManagerServiceProvider.php
@@ -52,6 +52,11 @@ class ManagerServiceProvider extends ServiceProvider {
             return new Console\CleanCommand($app['translation-manager']);
         });
         $this->commands('command.translation-manager.clean');
+
+        $this->app->singleton('command.translation-manager.sync', function ($app) {
+            return new Console\SyncCommand($app['translation-manager']);
+        });
+        $this->commands('command.translation-manager.sync');
 	}
 
     /**
@@ -91,6 +96,18 @@ class ManagerServiceProvider extends ServiceProvider {
             $router->post('/locales/remove', 'Controller@postRemoveLocale');
             $router->post('/publish/{groupKey}', 'Controller@postPublish')->where('groupKey', '.*');
         });
+
+        // Translation API routes
+        if($this->app['config']->get('translation-manager.api_endpoints_enabled', false)) {
+            $apiConfig = array_merge($config, $this->app['config']->get('translation-manager.api_route', []));
+
+            $router->group($apiConfig, function($router)
+            {
+                $router->get('/locales', 'Controller@getLocales');
+                $router->get('/locales/{slug}', 'Controller@getLocaleTranslations');
+            });
+        }
+
 	}
 
 	/**
@@ -105,7 +122,8 @@ class ManagerServiceProvider extends ServiceProvider {
             'command.translation-manager.import',
             'command.translation-manager.find',
             'command.translation-manager.export',
-            'command.translation-manager.clean'
+            'command.translation-manager.clean',
+            'command.translation-manager.sync',
         );
 	}
 


### PR DESCRIPTION
This merge request contains my previous auto translate merge request.

The changes will allow the user to sync translations from a remote deployment. Use-case: if the translations are updated on the staging/production environment, the developer should be able to compare and extract those changes and optionally commit the to the repository. 