### PR TITLE
config is now compatible with >= 5.2 and < 5.2

### DIFF
--- a/config/translation-manager.php
+++ b/config/translation-manager.php
@@ -10,8 +10,14 @@ return [
     | The default group settings for the elFinder routes.
     |
     */
-    'route'          => [
-        'prefix'     => 'translations',
+    'route' => version_compare(app()::VERSION, '5.2', '>=') ? [
+        'prefix' => 'translations',
+        'middleware' => [
+            'web',
+            'auth',
+        ],
+    ] : [
+        'prefix' => 'translations',
         'middleware' => 'auth',
     ],
 


### PR DESCRIPTION
Adds a simple version comparison to the config, so laravel >= 5.2 does not need a manual edit of the config.

TODO: 
[ ] Delete instructions from README for manual edit.