### PR TITLE
Do not group with space after the dot

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -164,7 +164,7 @@ class Manager
             "[\'\"]" .                           // Match " or '
             '(' .                                // Start a new group to match:
             '[a-zA-Z0-9_-]+' .               // Must start with group
-            "([.|\/][^\1)]+)+" .             // Be followed by one or more items/keys
+            "([.|\/](?! )[^\1)]+)+" .             // Be followed by one or more items/keys
             ')' .                                // Close group
             "[\'\"]" .                           // Closing quote
             "[\),]";                            // Close parentheses or new parameter


### PR DESCRIPTION
`@lang('language.line')` has a group but `@lang('language. line')` should not be matched as group. Real example: `@lang('incl. VAT')`, this is just a json translation. I used this to test it: https://regexr.com/3u8k0