### PR TITLE
Case sensitive collation

### DIFF
--- a/database/migrations/2014_04_02_193005_create_translations_table.php
+++ b/database/migrations/2014_04_02_193005_create_translations_table.php
@@ -14,6 +14,7 @@ class CreateTranslationsTable extends Migration {
 	{
         Schema::create('ltm_translations', function(Blueprint $table)
         {
+	    $table->collation = 'utf8mb4_bin';
             $table->increments('id');
             $table->integer('status')->default(0);
             $table->string('locale');


### PR DESCRIPTION
https://github.com/barryvdh/laravel-translation-manager/issues/165, without it it's not possible to add `test` and `TEST`.

For people with existing tables run: `alter table ltm_translations convert to character set utf8mb4 collate utf8mb4_bin;`