### PR TITLE
Delete translations with keys has special characters

### DIFF
--- a/resources/views/index.php
+++ b/resources/views/index.php
@@ -212,7 +212,7 @@
                     <?php endforeach; ?>
                     <?php if ($deleteEnabled): ?>
                         <td>
-                            <a href="<?php echo action('\Barryvdh\TranslationManager\Controller@postDelete', [$group, $key]) ?>"
+                            <a href="<?php echo action('\Barryvdh\TranslationManager\Controller@postDelete', [$group, base64_encode($key)]) ?>"
                                class="delete-key"
                                data-confirm="Are you sure you want to delete the translations for '<?php echo htmlentities($key, ENT_QUOTES, 'UTF-8', false) ?>?"><span
                                         class="glyphicon glyphicon-trash"></span></a>

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -104,6 +104,7 @@ class Controller extends BaseController
 
     public function postDelete($group = null, $key)
     {
+        $key = base64_decode($key);
         if(!in_array($group, $this->manager->getConfig('exclude_groups')) && $this->manager->getConfig('delete_enabled')) {
             Translation::where('group', $group)->where('key', $key)->delete();
             return ['status' => 'ok'];


### PR DESCRIPTION
Hello,

My application uses translation strings as keys which are stored under `_json` group when the keys contain special characters and I try to choose the `_json` group to edit, I got the following error

`Missing required parameters for [Route: ] [URI: translations/delete/{groupKey}/{translationKey}]. (View: /resources/views/vendor/translation-manager/index.blade.php)`

to overcome this issue, I found that the best way is to `base64_encode` the translation `key` and `base64_decode` it on the controller.

This PR will fix this issue #254 so please review it and feed me back if you have any comments

Thanks