### PR TITLE
(feature) add config parameter to disable group detection for find

### DIFF
--- a/config/translation-manager.php
+++ b/config/translation-manager.php
@@ -35,6 +35,15 @@ return [
      *    )
      */
     'exclude_groups' => [],
+    
+    /**
+     * Disable Group Detection for the php artisan translations:find command
+     * Can be useful if you have group signs in the translation string keys (like points)
+     * 
+     * @type boolean
+     * 
+     */
+    'disable_group_detection_for_find'  => true,
 
     /**
      * Exclude specific languages from Laravel Translation Manager.

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -185,10 +185,12 @@ class Manager
         /** @var \Symfony\Component\Finder\SplFileInfo $file */
         foreach ( $finder as $file ) {
             // Search the current file for the pattern
-            if ( preg_match_all( "/$groupPattern/siU", $file->getContents(), $matches ) ) {
-                // Get all matches
-                foreach ( $matches[ 2 ] as $key ) {
-                    $groupKeys[] = $key;
+            if(!isset($this->config['disable_group_detection_for_find']) || $this->config['disable_group_detection_for_find']===false) {
+                if ( preg_match_all( "/$groupPattern/siU", $file->getContents(), $matches ) ) {
+                    // Get all matches
+                    foreach ( $matches[ 2 ] as $key ) {
+                        $groupKeys[] = $key;
+                    }
                 }
             }
 


### PR DESCRIPTION
Config parameter to disable Group Detection for the php artisan translations:find command
Can be useful if you have group signs in the translation string keys (like points)