### PR TITLE
On Add Locale Add Laravel Base Translation Files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "illuminate/support": "5.5.x|5.6.x|5.7.x|5.8.x",
     "illuminate/translation": "5.5.x|5.6.x|5.7.x|5.8.x",
     "symfony/finder": "~3.0|~4.0",
-    "tanmuhittin/laravel-google-translate": "^0.11.0"
+    "tanmuhittin/laravel-google-translate": "^0.11.0",
+    "andrey-helldar/laravel-lang-publisher": "^1.0|^1.5"
   },
   "autoload": {
     "psr-4": {

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -7,6 +7,7 @@ use Barryvdh\TranslationManager\Models\Translation;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Artisan;
 use Symfony\Component\Finder\Finder;
 
 class Manager
@@ -398,8 +399,15 @@ class Manager
         $this->ignoreLocales = $this->getIgnoredLocales();
 
         if ( !$this->files->exists( $localeDir ) || !$this->files->isDirectory( $localeDir ) ) {
-            return $this->files->makeDirectory( $localeDir );
+            if(!$this->files->makeDirectory( $localeDir )){
+                return false;
+            }
         }
+        Artisan::call('lang:install',
+            [
+                'lang' => [$locale]
+            ]);
+        $this->importTranslations(false);
 
         return true;
     }


### PR DESCRIPTION
This PR uses https://github.com/caouecs/Laravel-lang via https://github.com/andrey-helldar/laravel-lang-publisher package lang:install artisan command to add localization files.

Related :
- https://github.com/andrey-helldar/laravel-lang-publisher/pull/3
- https://github.com/caouecs/Laravel-lang/issues/1055