### PR TITLE
fix: wrong override recurring variable

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -64,8 +64,8 @@ class Manager
 
             //import langfiles for each vendor
             if ( $locale == 'vendor' ) {
-                foreach ( $this->files->directories( $langPath ) as $vendor ) {
-                    $counter += $this->importTranslations( $replace, $vendor );
+                foreach ( $this->files->directories( $langPath ) as $vendorDir ) {
+                    $counter += $this->importTranslations( $replace, $vendorDir );
                 }
                 continue;
             }


### PR DESCRIPTION
![Screen Shot 2019-07-11 at 1 03 55 PM](https://user-images.githubusercontent.com/13985803/61023485-c5500880-a3dc-11e9-99fd-f4635865b866.png)

Please pull this,
its override the $vendor variable, makes the following files after lang/vendor cannot be indexed correctly.

Thanks.