### PR TITLE
Add export all option to Artisan comman

### DIFF
--- a/src/Console/ExportCommand.php
+++ b/src/Console/ExportCommand.php
@@ -52,7 +52,12 @@ class ExportCommand extends Command
             return;
         }
 
-        $this->manager->exportTranslations($group, $json);
+        if ( $group == '*' ) {
+            $this->manager->exportAllTranslations();
+        }
+        else {
+            $this->manager->exportTranslations($group, $json);
+        }
 
         if (!is_null($group)) {
             $this->info('Done writing language files for '.(($group == '*') ? 'ALL groups' : $group.' group'));


### PR DESCRIPTION
According to the success message it is possible to export all translations by specifying * as group argument. This unfortunately doesn't work.