### PR TITLE
Add Laravel 6 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "illuminate/support": "^5.5|^6",
     "illuminate/translation": "^5.5|^6",
     "symfony/finder": "^3|^4",
-    "tanmuhittin/laravel-google-translate": "^1.0.1"
+    "tanmuhittin/laravel-google-translate": "^1.0.2"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Use tanmuhittin/laravel-google-translate v1.0.2
Bonus: Now TranslateFilesCommand::translate function respects parameters( :attribute ) https://github.com/tanmuhittin/laravel-google-translate/issues/5 thanks to @DanielMalmgren  