### PR TITLE
Fix for doing a string match of translation functions which span mult…

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -180,11 +180,11 @@ class Manager
         $stringPattern =
             "[^\w]".                                     // Must not have an alphanum before real method
             '('.implode('|', $functions).')'.             // Must start with one of the functions
-            "\(".                                          // Match opening parenthesis
+            "\(\s*".                                       // Match opening parenthesis
             "(?P<quote>['\"])".                            // Match " or ' and store in {quote}
             "(?P<string>(?:\\\k{quote}|(?!\k{quote}).)*)". // Match any string that can be {quote} escaped
             "\k{quote}".                                   // Match " or ' previously matched
-            "[\),]";                                       // Close parentheses or new parameter
+            "\s*[\),]";                                    // Close parentheses or new parameter
 
         // Find all PHP + Twig files in the app folder, except for storage
         $finder = new Finder();


### PR DESCRIPTION
This is a fix for parsing translations from files where the translation function spans multiple lines.

e.g.

```
__(
    'foobar'
);
```

The existing string matching only works if there is no space between the start and end parentheses - 

`__('foobar');`

This is often encountered, especially when you have parameterized translations and the code necessarily spans multiple lines:

e.g. 

```
__(
    'foobar :foo and :bar',
    [
        'foo' => 'foo',
        'bar' => 'bar',
    ]
);
```
