### PR TITLE
Use brick varexporter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "illuminate/support": "^5.5|^6",
     "illuminate/translation": "^5.5|^6",
     "symfony/finder": "^3|^4",
-    "tanmuhittin/laravel-google-translate": "^1.0.2"
+    "tanmuhittin/laravel-google-translate": "^1.0.2",
+    "brick/varexporter": "^0.2.1"
   },
   "autoload": {
     "psr-4": {

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application;
 use Barryvdh\TranslationManager\Models\Translation;
 use Barryvdh\TranslationManager\Events\TranslationsExportedEvent;
+use Symfony\Component\VarExporter\VarExporter;
 
 class Manager
 {
@@ -294,7 +295,7 @@ class Manager
 
                         $path = $path.DIRECTORY_SEPARATOR.$locale.DIRECTORY_SEPARATOR.$group.'.php';
 
-                        $output = "<?php\n\nreturn ".var_export($translations, true).';'.\PHP_EOL;
+                        $output = "<?php\n\nreturn ".VarExporter::export($translations).';'.\PHP_EOL;
                         $this->files->put($path, $output);
                     }
                 }


### PR DESCRIPTION
This PR uses [brick/varexporter](https://github.com/brick/varexporter), instead of `var_export()` to export translations to files.

This package outputs a much cleaner and "prettier" PHP code also using newer array syntax and indentation.