### PR TITLE
Issue 310 include lang namespaces

### DIFF
--- a/database/migrations/2019_10_24_115350_create_namespaces_table.php
+++ b/database/migrations/2019_10_24_115350_create_namespaces_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateNamespacesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('ltm_namespaces', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('namespace');
+            $table->string('path');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('namespaces');
+    }
+}

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -313,16 +313,23 @@ class Manager
                                                     ->orderByGroupKeys(Arr::get($this->config, 'sort_keys', false))
                                                     ->get());
 
+                $namespaces = TranslationNamespace::all()->pluck('path', 'namespace');
+
                 foreach ($tree as $locale => $groups) {
                     if (isset($groups[$group])) {
                         $translations = $groups[$group];
                         $path = $this->app['path.lang'];
 
-                        $locale_path = $locale.DIRECTORY_SEPARATOR.$group;
-                        if ($vendor) {
-                            $path = $basePath.'/'.$group.'/'.$locale;
-                            $locale_path = Str::after($group, '/');
+                        if (Str::contains($group, '::')) {
+                            list($namespace, $group) = explode('::', $group, 2);
+                            $path = $namespaces[$namespace] ?? $this->app['path.lang'];
                         }
+
+                        if ($vendor) {
+                            list($package, $group) = explode('/', Str::after($group, 'vendor/'), 2);
+                            $path = $basePath . DIRECTORY_SEPARATOR .'vendor'. DIRECTORY_SEPARATOR . $package;
+                        }
+                        $locale_path = $locale.DIRECTORY_SEPARATOR.$group;
                         $subfolders = explode(DIRECTORY_SEPARATOR, $locale_path);
                         array_pop($subfolders);
 

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -9,6 +9,7 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application;
 use Barryvdh\TranslationManager\Models\Translation;
+use Barryvdh\TranslationManager\Models\TranslationNamespace;
 use Barryvdh\TranslationManager\Events\TranslationsExportedEvent;
 
 class Manager
@@ -128,6 +129,13 @@ class Manager
                     foreach (Arr::dot($translations) as $key => $value) {
                         $importedTranslation = $this->importTranslation($key, $value, $locale, $group, $replace);
                         $counter += $importedTranslation ? 1 : 0;
+                    }
+
+                    if ($namespace) {
+                        TranslationNamespace::updateOrCreate(
+                            ['namespace' => $namespace],
+                            ['path' => $base]
+                        );
                     }
                 }
             }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -415,6 +415,7 @@ class Manager
     public function truncateTranslations()
     {
         Translation::truncate();
+        TranslationNamespace::truncate();
     }
 
     public function getLocales()

--- a/src/Models/TranslationNamespace.php
+++ b/src/Models/TranslationNamespace.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Barryvdh\TranslationManager\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TranslationNamespace extends Model
+{
+    protected $table = 'ltm_namespaces';
+    protected $guarded = ['id', 'created_at', 'updated_at'];
+}


### PR DESCRIPTION
This PR addresses issue #310 

It creates a new database table (`ltm_namespaces`) to store declared translation namespaces' language paths.

It refactors the import and export processes to handle registered namespaces in service providers. It creates groups with the form `namespace::group` for each of them. It also breaks down each vendor translations into a separate group (`vendor/vendorname/group`) instead of joining all translations into a single one.

The `Manager::importTranslations()` method, AFAIK, is only publicly called with the `$replace` argument and both other arguments are for internal use, so I refactored it to have only this argument and broke it down into two other methods, one for array translations and another for JSON.   