### PR TITLE
Upgrade tanmuhittin/laravel-google-translate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "illuminate/support": "^5.5|^6|^7",
     "illuminate/translation": "^5.5|^6|^7",
     "symfony/finder": "^3|^4|^5",
-    "tanmuhittin/laravel-google-translate": "^1.0.2"
+    "tanmuhittin/laravel-google-translate": "^2.0.1"
   },
   "autoload": {
     "psr-4": {

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -184,7 +184,7 @@ class Controller extends BaseController
                     // Translation already exists. Skip
                     continue;
                 }
-                $translated_text = Str::translate($base_string->value, $newLocale, $base_locale);
+                $translated_text = Str::apiTranslate($base_string->value, $newLocale, $base_locale);
                 request()->replace([
                     'value' => $translated_text,
                     'name' => $newLocale . '|' . $base_string->key,

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -4,7 +4,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller as BaseController;
 use Barryvdh\TranslationManager\Models\Translation;
 use Illuminate\Support\Collection;
-use Tanmuhittin\LaravelGoogleTranslate\Commands\TranslateFilesCommand;
+use Illuminate\Support\Str;
 
 class Controller extends BaseController
 {
@@ -184,7 +184,7 @@ class Controller extends BaseController
                     // Translation already exists. Skip
                     continue;
                 }
-                $translated_text = TranslateFilesCommand::translate($base_locale, $newLocale, $base_string->value);
+                $translated_text = Str::translate($base_string->value, $newLocale, $base_locale);
                 request()->replace([
                     'value' => $translated_text,
                     'name' => $newLocale . '|' . $base_string->key,

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -184,7 +184,7 @@ class Controller extends BaseController
                     // Translation already exists. Skip
                     continue;
                 }
-                $translated_text = Str::apiTranslate($base_string->value, $newLocale, $base_locale);
+                $translated_text = Str::apiTranslateWithAttributes($base_string->value, $newLocale, $base_locale);
                 request()->replace([
                     'value' => $translated_text,
                     'name' => $newLocale . '|' . $base_string->key,


### PR DESCRIPTION
New features:
* Provide extra facade functions Str::apiTranslate and Str::apiTranslateWithAttributes
* Yandex translation api support added
* Now you can define your own custom translator
* Better, readable code
* Use official packages for translation : google/cloud-translate and yandex/translate-api
* Still supports no key translations using stichoza/google-translate-php