### PR TITLE
fixed delete translation confirmation

### DIFF
--- a/resources/views/index.php
+++ b/resources/views/index.php
@@ -50,14 +50,17 @@
                 }
             });
 
-            $("a.delete-key").click(function(event){
-              event.preventDefault();
-              var row = $(this).closest('tr');
-              var url = $(this).attr('href');
-              var id = row.attr('id');
-              $.post( url, {id: id}, function(){
-                  row.remove();
-              } );
+            $("a.delete-key").on('confirm:complete',function(event,result){
+                if(result)
+                {
+                    var row = $(this).closest('tr');
+                    var url = $(this).attr('href');
+                    var id = row.attr('id');
+                    $.post( url, {id: id}, function(){
+                        row.remove();
+                    } );
+                }
+                return false;
             });
 
             $('.form-import').on('ajax:success', function (e, data) {


### PR DESCRIPTION
https://github.com/rails/jquery-ujs/blob/master/src/rails.js#L292

I suggest you to catch `confirm:complete` instead of `click` event so we can read and manipulate `confirm()` result for our sake. The main problem is we want to send ajax request so we can delete translate rows without refreshing page but we cannot achieve that without manipulating `confirm:complete`, as result we have to return false to stay in same page.