### PR TITLE
Moving optional variables for PHP 8

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -103,7 +103,7 @@ class Controller extends BaseController
         }
     }
 
-    public function postDelete($group = null, $key)
+    public function postDelete($key, $group = null)
     {
         if(!in_array($group, $this->manager->getConfig('exclude_groups')) && $this->manager->getConfig('delete_enabled')) {
             Translation::where('group', $group)->where('key', $key)->delete();


### PR DESCRIPTION
when using PHP 8 there will be an exception while doing ```php artisan route:list```

Required parameter $key follows optional parameter $group