### PR TITLE
handle error  if base_string value is null

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -184,17 +184,19 @@ class Controller extends BaseController
                     // Translation already exists. Skip
                     continue;
                 }
-                $translated_text = Str::apiTranslateWithAttributes($base_string->value, $newLocale, $base_locale);
-                request()->replace([
-                    'value' => $translated_text,
-                    'name' => $newLocale . '|' . $base_string->key,
-                ]);
-                app()->call(
-                    'Barryvdh\TranslationManager\Controller@postEdit',
-                    [
-                        'group' => $group
-                    ]
-                );
+                if(!empty($base_string->value)) {
+                    $translated_text = Str::apiTranslateWithAttributes($base_string->value, $newLocale, $base_locale);
+                    request()->replace([
+                        'value' => $translated_text,
+                        'name' => $newLocale . '|' . $base_string->key,
+                    ]);
+                    app()->call(
+                        'Barryvdh\TranslationManager\Controller@postEdit',
+                        [
+                            'group' => $group
+                        ]
+                    );
+                }
             }
             return redirect()->back();
         }


### PR DESCRIPTION
TypeError
Argument 1 passed to Illuminate\Support\Str::Tanmuhittin\LaravelGoogleTranslate\{closure}() must be of the type string, null given, called in /home/anskal/Work/web/vendor/laravel/framework/src/Illuminate/Support/Traits/Macroable.php on line 88

https://flareapp.io/share/bP9QaJOP