### PR TITLE
change in transaction table name & databae connection

### DIFF
--- a/config/translation-manager.php
+++ b/config/translation-manager.php
@@ -36,6 +36,11 @@ return [
      */
     'exclude_groups' => [],
 
+    'database' => [
+        'table'         => env('TRANSLATION_TABLE_NAME', 'ltm_translations'),
+        'connection'    => env('TRANSLATION_CONNECTION', 'mysql'),
+    ],
+
     /**
      * Exclude specific languages from Laravel Translation Manager.
      *

--- a/src/Models/Translation.php
+++ b/src/Models/Translation.php
@@ -1,13 +1,16 @@
-<?php namespace Barryvdh\TranslationManager\Models;
+<?php
 
-use Illuminate\Database\Eloquent\Model;
+namespace Barryvdh\TranslationManager\Models;
+
+use App\Models\BaseModel;
 use DB;
+use Illuminate\Database\Eloquent\Model;
 
 /**
- * Translation model
+ * Translation model.
  *
- * @property integer $id
- * @property integer $status
+ * @property int $id
+ * @property int $status
  * @property string  $locale
  * @property string  $group
  * @property string  $key
@@ -15,20 +18,31 @@ use DB;
  * @property \Carbon\Carbon $created_at
  * @property \Carbon\Carbon $updated_at
  */
-class Translation extends Model{
+class Translation extends BaseModel
+{
+    public const STATUS_SAVED = 0;
 
-    const STATUS_SAVED = 0;
-    const STATUS_CHANGED = 1;
+    public const STATUS_CHANGED = 1;
 
     protected $table = 'ltm_translations';
-    protected $guarded = array('id', 'created_at', 'updated_at');
+
+    protected $connection = 'mysql';
+
+    public function __construct()
+    {
+        $this->connection = config('translation-manager.database.connection');
+        $this->table = config('translation-manager.database.table');
+    }
+
+    protected $guarded = ['id', 'created_at', 'updated_at'];
 
     public function scopeOfTranslatedGroup($query, $group)
     {
         return $query->where('group', $group)->whereNotNull('value');
     }
 
-    public function scopeOrderByGroupKeys($query, $ordered) {
+    public function scopeOrderByGroupKeys($query, $ordered)
+    {
         if ($ordered) {
             $query->orderBy('group')->orderBy('key');
         }
@@ -40,7 +54,7 @@ class Translation extends Model{
     {
         $select = '';
 
-        switch (DB::getDriverName()){
+        switch (DB::getDriverName()) {
             case 'mysql':
                 $select = 'DISTINCT `group`';
                 break;
@@ -51,5 +65,4 @@ class Translation extends Model{
 
         return $query->select(DB::raw($select));
     }
-
 }


### PR DESCRIPTION
If you develope a large system, and each part of the system has its own database, but at the same time speech and translation are one.
There must be a common database so that the databases are not repeated in more than one place and at the same time the translation is all the same and comes from one place
It is also possible to change in values from .env file or config.