### PR TITLE
allow a different table for the Translation model

### DIFF
--- a/config/translation-manager.php
+++ b/config/translation-manager.php
@@ -67,8 +67,9 @@ return [
     ],
 
     /**
-     * Database connection name to allow for different db connection for the translations table.
+     * Database table and connection name to allow for different db connection for the translations table.
      */
+    'db_table' => env('TRANSLATION_MANAGER_DB_TABLE', null),
     'db_connection' => env('TRANSLATION_MANAGER_DB_CONNECTION', null),
 
 ];

--- a/src/Models/Translation.php
+++ b/src/Models/Translation.php
@@ -53,6 +53,20 @@ class Translation extends Model{
     }
 
     /**
+     * Get the table associated with the model.
+     *
+     * @return string
+     */
+    public function getTable()
+    {
+        if ($table = config('translation-manager.db_table')){
+            return $table;
+        }
+
+        return parent::getTable();
+    }
+
+    /**
      * Get the current connection name for the model.
      *
      * @return string|null


### PR DESCRIPTION
Support the use of a different table for the translations.

This change assumes that the migration has been published and modified.