### PR TITLE
Prevent updated_at change on export

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -300,7 +300,7 @@ class Manager
                         $this->files->put($path, $output);
                     }
                 }
-                Translation::ofTranslatedGroup($group)->update(['status' => Translation::STATUS_SAVED]);
+                Translation::ofTranslatedGroup($group)->toBase()->update(['status' => Translation::STATUS_SAVED]);
             }
         }
 
@@ -318,7 +318,7 @@ class Manager
                 }
             }
 
-            Translation::ofTranslatedGroup(self::JSON_GROUP)->update(['status' => Translation::STATUS_SAVED]);
+            Translation::ofTranslatedGroup(self::JSON_GROUP)->toBase()->update(['status' => Translation::STATUS_SAVED]);
         }
 
         $this->events->dispatch(new TranslationsExportedEvent());


### PR DESCRIPTION
When doing an export of the translation files the state of the translation gets changed to saved. This is okay, but this statement also changes the updated_at timestamp of every translation in the exported groups. This way the updated_at column can't be used for anything. 

My commit changes the Eloquent/Builder query to a Database/Builder query to only update the state column.