### PR TITLE
Allow recording of default json group

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -39,6 +39,12 @@ class Translator extends LaravelTranslator {
     protected function notifyMissingKey($key)
     {
         list($namespace, $group, $item) = $this->parseKey($key);
+        
+        if($item === null){
+          $item = $group;
+          $group = '_json';
+        }
+        
         if($this->manager && $namespace === '*' && $group && $item ){
             $this->manager->missingKey($namespace, $group, $item);
         }


### PR DESCRIPTION
Currently if you use translations like  `@lang('Hello World')`  or  `{{ __('Hello World') }}`  the auto-detect when missing functionality doesn't record these. The patch suggested here addresses that so that a _json entry for Hello World is added to the database.