### PR TITLE
Fix variable anotation in config array

### DIFF
--- a/config/translation-manager.php
+++ b/config/translation-manager.php
@@ -18,7 +18,7 @@ return [
     /**
      * Enable deletion of translations
      *
-     * @type boolean
+     * @var boolean
      */
     'delete_enabled' => true,
 
@@ -26,7 +26,7 @@ return [
      * Exclude specific groups from Laravel Translation Manager.
      * This is useful if, for example, you want to avoid editing the official Laravel language files.
      *
-     * @type array
+     * @var array
      *
      *    array(
      *        'pagination',
@@ -39,7 +39,7 @@ return [
     /**
      * Exclude specific languages from Laravel Translation Manager.
      *
-     * @type array
+     * @var array
      *
      *    array(
      *        'fr',


### PR DESCRIPTION
You have used @type array to specify the type of the array. However, in PHPDoc comments, it's more common to use @var to specify the type of a variable within an array.

https://docs.phpdoc.org/3.0/guide/references/phpdoc/tags/index.html