### PR TITLE
remove get() before pluck when don't have relation eager loading

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -25,7 +25,7 @@ class Controller extends BaseController
             $groups->whereNotIn('group', $excludedGroups);
         }
 
-        $groups = $groups->select('group')->orderBy('group')->get()->pluck('group', 'group');
+        $groups = $groups->select('group')->orderBy('group')->pluck('group', 'group');
         if ($groups instanceof Collection) {
             $groups = $groups->all();
         }
@@ -61,7 +61,6 @@ class Controller extends BaseController
         //Set the default locale as the first one.
         $locales = Translation::groupBy('locale')
             ->select('locale')
-            ->get()
             ->pluck('locale');
 
         if ($locales instanceof Collection) {


### PR DESCRIPTION
when we don't have eager loading, so we can directly call pluck() instead of get()->pluck()