### PR TITLE
Make Routes Optional via Configuration

### DIFF
--- a/config/translation-manager.php
+++ b/config/translation-manager.php
@@ -16,6 +16,13 @@ return [
     ],
 
     /**
+     * Enable routes for Laravel Translation Manager
+     *
+     * @type boolean
+     */
+    'routes_enabled' => true,
+
+    /**
      * Enable deletion of translations
      *
      * @type boolean

--- a/src/ManagerServiceProvider.php
+++ b/src/ManagerServiceProvider.php
@@ -72,7 +72,9 @@ class ManagerServiceProvider extends ServiceProvider {
             $migrationPath => base_path('database/migrations'),
         ], 'migrations');
 
-        $this->loadRoutesFrom(__DIR__.'/routes.php');
+        if (config('translation-manager.routes_enabled', true)) {
+            $this->loadRoutesFrom(__DIR__ . '/routes.php');
+        }
 	}
 
 	/**


### PR DESCRIPTION
Added the ability to optionally disable all routes provided by the package. This enhancement is useful for those using Laravel as an API and who manage translations through their own custom routes, eliminating the need for the package's routes to be published to the application.