### PR TITLE
Fix for mariadb driver

### DIFF
--- a/src/Models/Translation.php
+++ b/src/Models/Translation.php
@@ -42,6 +42,7 @@ class Translation extends Model{
 
         switch (DB::getDriverName()){
             case 'mysql':
+            case 'mariadb':
                 $select = 'DISTINCT `group`';
                 break;
             default:


### PR DESCRIPTION
Now that we can use mariadb as a db driver, this should be added to the scopeSelectDistinctGroup() method. Currently we can't use the package because it's using the wrong syntax. 

This small PR fixes this issues. Can you please merge this asap?

Cheers!