### PR TITLE
add Schema definition

### DIFF
--- a/database/migrations/2014_04_02_193005_create_translations_table.php
+++ b/database/migrations/2014_04_02_193005_create_translations_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
 
 class CreateTranslationsTable extends Migration {
 


### PR DESCRIPTION
`Schema` is not defined in the migration file. This PR addresses this issue.