### PR TITLE
remove unnecessary id="username"

### DIFF
--- a/resources/views/index.php
+++ b/resources/views/index.php
@@ -255,7 +255,7 @@
                             <a href="#edit"
                                class="editable status-<?php echo $t ? $t->status : 0 ?> locale-<?php echo $locale ?>"
                                data-locale="<?php echo $locale ?>" data-name="<?php echo $locale . "|" . htmlentities($key, ENT_QUOTES, 'UTF-8', false) ?>"
-                               id="username" data-type="textarea" data-pk="<?php echo $t ? $t->id : 0 ?>"
+                               data-type="textarea" data-pk="<?php echo $t ? $t->id : 0 ?>"
                                data-url="<?php echo $editUrl ?>"
                                data-title="Enter translation"><?php echo $t ? htmlentities($t->value, ENT_QUOTES, 'UTF-8', false) : '' ?></a>
                         </td>


### PR DESCRIPTION
This PR removes `id="username"` since it is never used in CSS, JS, and PHP, and it appears inside a loop, which violates HTML standards.