### PR TITLE
include total number of all changed translations

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -32,6 +32,7 @@ class Controller extends BaseController
         $groups = [''=>'Choose a group'] + $groups;
         $numChanged = Translation::where('group', $group)->where('status', Translation::STATUS_CHANGED)->count();
 
+        $allNumChanged = Translation::where('status', Translation::STATUS_CHANGED)->count();
 
         $allTranslations = Translation::where('group', $group)->orderBy('key', 'asc')->get();
         $numTranslations = count($allTranslations);
@@ -47,6 +48,7 @@ class Controller extends BaseController
             ->with('group', $group)
             ->with('numTranslations', $numTranslations)
             ->with('numChanged', $numChanged)
+            ->with('allNumChanged', $allNumChanged)
             ->with('editUrl', $group ? action('\Barryvdh\TranslationManager\Controller@postEdit', [$group]) : null)
             ->with('deleteEnabled', $this->manager->getConfig('delete_enabled'));
     }


### PR DESCRIPTION
It is good for project managers to easily see the total number of translations changed; not just by group.