### PR TITLE
remove unnecessary return

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -196,7 +196,6 @@ class Controller extends BaseController
                     ]
                 );
             }
-            return redirect()->back();
         }
         return redirect()->back();
     }


### PR DESCRIPTION
The function `postTranslateMissing()` has an unnecessary `return redirect()->back();` in the `if` statement. An exact return happens after the statement, anyway.