### PR TITLE
Fix memory issue in export command

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -266,9 +266,14 @@ class Manager
                     }
                 }
 
-                $tree = $this->makeTree(Translation::ofTranslatedGroup($group)
-                                                    ->orderByGroupKeys(Arr::get($this->config, 'sort_keys', false))
-                                                    ->get());
+                $models = [];
+                Translation::ofTranslatedGroup($group)
+                    ->orderByGroupKeys(Arr::get($this->config, 'sort_keys', false))
+                    ->chunkById(50000, function ($chunk) use (&$models) {
+                        $models = array_merge($models, $chunk->all());
+                    });
+
+                $tree = $this->makeTree($models);
 
                 foreach ($tree as $locale => $groups) {
                     $locale = basename($locale);


### PR DESCRIPTION
Fetch translations in chunks to avoid early memory exhaustion when exporting large volumes of translations from the DB.

For reference, our `ltm_translations` table has over 300K records from the same group (1 excessively large `app.php` lang file serving dozens of locales) - chunking unblocks `php artisan translations:export app`, though I do appreciate we do have an unusually large lang file.

There are probably more memory efficient solutions than this that may or may not require a slightly smarter approach, but we can cross that bridge when it's necessary, this fix has been working well for us for some time now.