### PR TITLE
Allow `symfony/finder` v8 for Laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "php": "^8.1",
     "illuminate/support": "^9|^10|^11|^12|^13",
     "illuminate/translation": "^9|^10|^11|^12|^13",
-    "symfony/finder": "^6|^7"
+    "symfony/finder": "^6|^7|^8"
   },
   "require-dev": {
     "orchestra/testbench": "^7|^8|^9|^10|^11"


### PR DESCRIPTION
New installations of Laravel can't use the translation package because of a conflict with `symfony/finder` - allowing v8 resolves the issue and makes the package run on new installations of Laravel 13.

Looking at the changelogs from symfony/finder, nothing should be a breaking change at this point. I've tested v8 in a separate project and it seems to work fine.